### PR TITLE
Improve overlay sizing controls and resize limits.

### DIFF
--- a/Sources/V2SApp/Localization/AppLocalization.swift
+++ b/Sources/V2SApp/Localization/AppLocalization.swift
@@ -150,6 +150,7 @@ enum AppTextKey: String {
     case failedToStageWithReasonFormat
     case failedToReadCapturedAudioStreamFormat
     case scrollToLatestSubtitle
+    case resetOverlaySize
     case transcript
     case origin
     case translation
@@ -431,6 +432,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "Failed to %@: %@",
             "failedToReadCapturedAudioStreamFormat": "Failed to read the captured audio stream for %@.",
             "scrollToLatestSubtitle": "Scroll to latest subtitle",
+            "resetOverlaySize": "Reset overlay size",
             "transcript": "Transcript",
             "origin": "Origin",
             "translation": "Translation",
@@ -592,6 +594,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "无法%@：%@",
             "failedToReadCapturedAudioStreamFormat": "无法读取 %@ 的采集音频流。",
             "scrollToLatestSubtitle": "滚动到最新字幕",
+            "resetOverlaySize": "重置字幕窗大小",
             "transcript": "字幕记录",
             "origin": "原文",
             "translation": "译文",
@@ -753,6 +756,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "No se pudo %@: %@",
             "failedToReadCapturedAudioStreamFormat": "No se pudo leer el flujo de audio capturado de %@.",
             "scrollToLatestSubtitle": "Ir al subtítulo más reciente",
+            "resetOverlaySize": "Restablecer tamaño del overlay",
             "transcript": "Transcripción",
             "origin": "Original",
             "translation": "Traducción",
@@ -914,6 +918,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "%@ fehlgeschlagen: %@",
             "failedToReadCapturedAudioStreamFormat": "Der erfasste Audiostream von %@ konnte nicht gelesen werden.",
             "scrollToLatestSubtitle": "Zum neuesten Untertitel scrollen",
+            "resetOverlaySize": "Overlay-Größe zurücksetzen",
             "transcript": "Transkript",
             "origin": "Original",
             "translation": "Übersetzung",
@@ -1075,6 +1080,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "%@ に失敗しました: %@",
             "failedToReadCapturedAudioStreamFormat": "%@ のキャプチャ音声ストリームを読み取れませんでした。",
             "scrollToLatestSubtitle": "最新の字幕へ移動",
+            "resetOverlaySize": "オーバーレイのサイズをリセット",
             "transcript": "トランスクリプト",
             "origin": "原文",
             "translation": "翻訳",
@@ -1236,6 +1242,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "Impossible de %@ : %@",
             "failedToReadCapturedAudioStreamFormat": "Impossible de lire le flux audio capturé pour %@.",
             "scrollToLatestSubtitle": "Aller au sous-titre le plus récent",
+            "resetOverlaySize": "Réinitialiser la taille de l'overlay",
             "transcript": "Transcription",
             "origin": "Original",
             "translation": "Traduction",
@@ -1397,6 +1404,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "%@ 실패: %@",
             "failedToReadCapturedAudioStreamFormat": "%@ 의 캡처된 오디오 스트림을 읽을 수 없습니다.",
             "scrollToLatestSubtitle": "최신 자막으로 이동",
+            "resetOverlaySize": "오버레이 크기 재설정",
             "transcript": "기록",
             "origin": "원문",
             "translation": "번역",
@@ -1558,6 +1566,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "تعذر %@: %@",
             "failedToReadCapturedAudioStreamFormat": "تعذر قراءة دفق الصوت الملتقط لـ %@.",
             "scrollToLatestSubtitle": "الانتقال إلى أحدث ترجمة",
+            "resetOverlaySize": "إعادة تعيين حجم التراكب",
             "transcript": "النص المكتوب",
             "origin": "الأصل",
             "translation": "الترجمة",
@@ -1719,6 +1728,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "Falha ao %@: %@",
             "failedToReadCapturedAudioStreamFormat": "Não foi possível ler o fluxo de áudio capturado de %@.",
             "scrollToLatestSubtitle": "Ir para a legenda mais recente",
+            "resetOverlaySize": "Redefinir tamanho da sobreposição",
             "transcript": "Transcrição",
             "origin": "Original",
             "translation": "Tradução",
@@ -1880,6 +1890,7 @@ enum AppLocalization {
             "failedToStageWithReasonFormat": "Не удалось %@: %@",
             "failedToReadCapturedAudioStreamFormat": "Не удалось прочитать захваченный аудиопоток для %@.",
             "scrollToLatestSubtitle": "Прокрутить к последнему субтитру",
+            "resetOverlaySize": "Сбросить размер оверлея",
             "transcript": "Транскрипция",
             "origin": "Оригинал",
             "translation": "Перевод",

--- a/Sources/V2SApp/UI/Overlay/OverlayView.swift
+++ b/Sources/V2SApp/UI/Overlay/OverlayView.swift
@@ -1,6 +1,10 @@
 import AppKit
 import SwiftUI
 
+enum OverlayPanelMetrics {
+    static let cornerRadius: CGFloat = 16
+}
+
 struct OverlayView: View {
     @ObservedObject var model: AppModel
     @ObservedObject var interactionState: OverlayInteractionState
@@ -115,7 +119,7 @@ struct OverlayView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(backgroundView)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    RoundedRectangle(cornerRadius: OverlayPanelMetrics.cornerRadius, style: .continuous)
                         .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
                 )
             }
@@ -588,7 +592,7 @@ struct OverlayView: View {
     // MARK: - Background
 
     private var backgroundView: some View {
-        RoundedRectangle(cornerRadius: 16, style: .continuous)
+        RoundedRectangle(cornerRadius: OverlayPanelMetrics.cornerRadius, style: .continuous)
             .fill(baseBackgroundColor.opacity(model.overlayStyle.backgroundOpacity))
     }
 
@@ -823,10 +827,10 @@ private struct OverlayTranslationHostModifier: ViewModifier {
 
 struct OverlayControlsChromeView: View {
     var body: some View {
-        RoundedRectangle(cornerRadius: 9, style: .continuous)
+        RoundedRectangle(cornerRadius: OverlayPanelMetrics.cornerRadius, style: .continuous)
             .fill(Color.black.opacity(0.28))
             .overlay(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                RoundedRectangle(cornerRadius: OverlayPanelMetrics.cornerRadius, style: .continuous)
                     .strokeBorder(Color.white.opacity(0.08), lineWidth: 0.5)
             )
             .frame(width: OverlayControlsLayout.stripSize.width, height: OverlayControlsLayout.stripSize.height)
@@ -903,6 +907,25 @@ struct OverlayResizeButtonView: View {
                 .frame(width: 10, height: 10)
                 .allowsHitTesting(false)
         )
+    }
+}
+
+struct OverlayResetSizeButtonView: View {
+    @ObservedObject var model: AppModel
+    let onReset: () -> Void
+
+    var body: some View {
+        Button { onReset() } label: {
+            ZStack {
+                Circle().fill(Color.white.opacity(0.12))
+                Image(systemName: "arrow.counterclockwise")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundColor(.white.opacity(0.65))
+            }
+        }
+        .buttonStyle(.plain)
+        .frame(width: OverlayControlsLayout.controlSize, height: OverlayControlsLayout.controlSize)
+        .accessibilityLabel(model.localized(.resetOverlaySize))
     }
 }
 
@@ -1069,11 +1092,25 @@ enum OverlayControlsLayout {
     static let controlSize: CGFloat = 22
     static let controlSpacing: CGFloat = 6
 
+    static let controlCount = 4
+
     static var stripSize: CGSize {
-        CGSize(
+        let controlStackHeight = (controlSize * CGFloat(controlCount))
+            + (controlSpacing * CGFloat(controlCount - 1))
+        return CGSize(
             width: controlSize + (controlPaddingX * 2),
-            height: (controlSize * 3) + (controlSpacing * 2) + (controlPaddingY * 2)
+            height: controlStackHeight + (controlPaddingY * 2)
         )
+    }
+
+    /// Control panel chrome height (four buttons + vertical padding inside the strip).
+    static var controlPanelHeight: CGFloat {
+        stripSize.height
+    }
+
+    /// Overlay must be at least this tall so the chrome strip (offset by `outerPadding` from the bottom) fits inside.
+    static var minimumOverlayHeight: CGFloat {
+        controlPanelHeight + (outerPadding * 2)
     }
 }
 

--- a/Sources/V2SApp/UI/Overlay/OverlayWindowController.swift
+++ b/Sources/V2SApp/UI/Overlay/OverlayWindowController.swift
@@ -14,12 +14,14 @@ final class OverlayWindowController {
     private let moveButtonPanel: OverlayPanel
     private let closeButtonPanel: OverlayPanel
     private let resizeButtonPanel: OverlayPanel
+    private let resetSizeButtonPanel: OverlayPanel
     private let subtitleHostingView: NSHostingView<OverlayView>
     private let controlsChromeHostingView: NSHostingView<OverlayControlsChromeView>
     private let scrollbarHostingView: NSHostingView<OverlayHistoryScrollbarView>
     private let moveButtonHostingView: NSHostingView<OverlayMoveButtonView>
     private let closeButtonHostingView: NSHostingView<OverlayCloseButtonView>
     private let resizeButtonHostingView: NSHostingView<OverlayResizeButtonView>
+    private let resetSizeButtonHostingView: NSHostingView<OverlayResetSizeButtonView>
     private var cancellables = Set<AnyCancellable>()
     /// Top-left corner (minX, maxY) of the panel after a user drag. nil = use auto-position.
     private var userDefinedTopLeft: NSPoint?
@@ -101,6 +103,12 @@ final class OverlayWindowController {
             backing: .buffered,
             defer: false
         )
+        self.resetSizeButtonPanel = OverlayPanel(
+            contentRect: NSRect(origin: .zero, size: Self.controlButtonSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
         self.subtitleHostingView = NSHostingView(
             rootView: OverlayView(model: model, interactionState: interactionState)
         )
@@ -123,6 +131,9 @@ final class OverlayWindowController {
                 onResizeDragEnded: {}
             )
         )
+        self.resetSizeButtonHostingView = NSHostingView(
+            rootView: OverlayResetSizeButtonView(model: model, onReset: {})
+        )
 
         configurePanels()
         moveButtonHostingView.rootView = OverlayMoveButtonView(
@@ -138,6 +149,10 @@ final class OverlayWindowController {
             onResizeDragStart: { [weak self] in self?.beginResizeDrag() },
             onResizeDragChanged: { [weak self] translation in self?.updateResizeDrag(with: translation) },
             onResizeDragEnded: { [weak self] in self?.endResizeDrag() }
+        )
+        resetSizeButtonHostingView.rootView = OverlayResetSizeButtonView(
+            model: model,
+            onReset: { [weak self] in self?.resetOverlaySizeToDefault() }
         )
         scrollbarHostingView.rootView = OverlayHistoryScrollbarView(
             model: model,
@@ -173,6 +188,17 @@ final class OverlayWindowController {
 
         configurePanel(resizeButtonPanel, acceptsInput: true, level: controlLevel)
         resizeButtonPanel.contentView = resizeButtonHostingView
+
+        configurePanel(resetSizeButtonPanel, acceptsInput: true, level: controlLevel)
+        resetSizeButtonPanel.contentView = resetSizeButtonHostingView
+    }
+
+    private var leftControlPanels: [OverlayPanel] {
+        [controlsChromePanel, moveButtonPanel, closeButtonPanel, resizeButtonPanel, resetSizeButtonPanel]
+    }
+
+    private var leftControlButtonPanels: [OverlayPanel] {
+        [moveButtonPanel, resetSizeButtonPanel, closeButtonPanel, resizeButtonPanel]
     }
 
     private func configurePanel(_ panel: OverlayPanel, acceptsInput: Bool, level: NSWindow.Level) {
@@ -321,7 +347,7 @@ final class OverlayWindowController {
         )
 
         // Hide control panels during animation
-        let controlPanels = [controlsChromePanel, scrollbarPanel, moveButtonPanel, closeButtonPanel, resizeButtonPanel]
+        let controlPanels = leftControlPanels + [scrollbarPanel]
         controlPanels.forEach { $0.alphaValue = 0; $0.orderOut(nil) }
 
         // Set initial state for main panel
@@ -514,7 +540,7 @@ final class OverlayWindowController {
 
     private func fadeInControlPanels() {
         positionPanels()
-        let controlPanels = [controlsChromePanel, scrollbarPanel, moveButtonPanel, closeButtonPanel, resizeButtonPanel]
+        let controlPanels = leftControlPanels + [scrollbarPanel]
         controlPanels.forEach { $0.alphaValue = 0; $0.orderFront(nil) }
 
         NSAnimationContext.runAnimationGroup { context in
@@ -530,29 +556,17 @@ final class OverlayWindowController {
         panel.orderFront(nil)
         panel.orderFrontRegardless()
 
-        controlsChromePanel.orderFront(nil)
-        controlsChromePanel.orderFrontRegardless()
-
-        scrollbarPanel.orderFront(nil)
-        scrollbarPanel.orderFrontRegardless()
-
-        moveButtonPanel.orderFront(nil)
-        moveButtonPanel.orderFrontRegardless()
-
-        closeButtonPanel.orderFront(nil)
-        closeButtonPanel.orderFrontRegardless()
-
-        resizeButtonPanel.orderFront(nil)
-        resizeButtonPanel.orderFrontRegardless()
+        for controlPanel in leftControlPanels + [scrollbarPanel] {
+            controlPanel.orderFront(nil)
+            controlPanel.orderFrontRegardless()
+        }
     }
 
     private func orderOutAllPanels() {
         panel.orderOut(nil)
-        controlsChromePanel.orderOut(nil)
-        scrollbarPanel.orderOut(nil)
-        moveButtonPanel.orderOut(nil)
-        closeButtonPanel.orderOut(nil)
-        resizeButtonPanel.orderOut(nil)
+        for controlPanel in leftControlPanels + [scrollbarPanel] {
+            controlPanel.orderOut(nil)
+        }
     }
 
     private func positionPanels(animated: Bool = false) {
@@ -619,17 +633,17 @@ final class OverlayWindowController {
                 panel.animator().setFrame(overlayFrame, display: true)
                 controlsChromePanel.animator().setFrame(chromeFrame, display: true)
                 scrollbarPanel.animator().setFrame(scrollbarFrame, display: true)
-                moveButtonPanel.animator().setFrame(buttonFrames[0], display: true)
-                closeButtonPanel.animator().setFrame(buttonFrames[1], display: true)
-                resizeButtonPanel.animator().setFrame(buttonFrames[2], display: true)
+                for (buttonPanel, frame) in zip(leftControlButtonPanels, buttonFrames) {
+                    buttonPanel.animator().setFrame(frame, display: true)
+                }
             }
         } else {
             panel.setFrame(overlayFrame, display: true)
             controlsChromePanel.setFrame(chromeFrame, display: true)
             scrollbarPanel.setFrame(scrollbarFrame, display: true)
-            moveButtonPanel.setFrame(buttonFrames[0], display: true)
-            closeButtonPanel.setFrame(buttonFrames[1], display: true)
-            resizeButtonPanel.setFrame(buttonFrames[2], display: true)
+            for (buttonPanel, frame) in zip(leftControlButtonPanels, buttonFrames) {
+                buttonPanel.setFrame(frame, display: true)
+            }
         }
 
         if panelsShown {
@@ -638,11 +652,12 @@ final class OverlayWindowController {
     }
 
     private func resolvedPanelWidth(in visibleFrame: NSRect, style: OverlayStyle) -> Double {
+        let maximumWidth = min(style.maxWidth, visibleFrame.width)
         if let liveResizeWidth {
-            return min(max(liveResizeWidth, style.minWidth), style.maxWidth)
+            return min(max(liveResizeWidth, style.minWidth), maximumWidth)
         }
 
-        return min(max(visibleFrame.width * style.widthRatio, style.minWidth), style.maxWidth)
+        return min(max(visibleFrame.width * style.widthRatio, style.minWidth), maximumWidth)
     }
 
     private func clampedOverlayFrame(
@@ -693,7 +708,7 @@ final class OverlayWindowController {
             - OverlayControlsLayout.controlPaddingY
             - OverlayControlsLayout.controlSize
 
-        return (0..<3).map { index in
+        return (0..<OverlayControlsLayout.controlCount).map { index in
             NSRect(
                 x: buttonX,
                 y: topButtonY - CGFloat(index) * (OverlayControlsLayout.controlSize + OverlayControlsLayout.controlSpacing),
@@ -705,7 +720,7 @@ final class OverlayWindowController {
 
     private func resolvedPanelHeight(in visibleFrame: NSRect) -> Double {
         let minimumHeight = Self.minimumOverlayHeight
-        let maximumHeight = max(minimumHeight, visibleFrame.height * 0.5)
+        let maximumHeight = max(minimumHeight, visibleFrame.height)
         if let userDefinedHeight {
             return min(max(userDefinedHeight, minimumHeight), maximumHeight)
         }
@@ -776,7 +791,7 @@ final class OverlayWindowController {
         let minimumHeight = Self.minimumOverlayHeight
         let maximumHeight = max(
             minimumHeight,
-            min(resizeDragStartTopLeft.y - visibleFrame.minY, visibleFrame.height * 0.5)
+            resizeDragStartTopLeft.y - visibleFrame.minY
         )
         let newHeight = min(max(resizeDragStartHeight - translation.height, minimumHeight), maximumHeight)
 
@@ -786,7 +801,10 @@ final class OverlayWindowController {
             userDefinedHeight = newHeight
         } else {
             let rightEdgeX = resizeDragStartTopLeft.x + resizeDragStartWidth
-            let maximumWidth = min(style.maxWidth, rightEdgeX - visibleFrame.minX)
+            let maximumWidth = min(
+                min(style.maxWidth, visibleFrame.width),
+                rightEdgeX - visibleFrame.minX
+            )
             let newWidth = min(max(resizeDragStartWidth - translation.width, style.minWidth), maximumWidth)
             let newWidthRatio = newWidth / visibleFrame.width
             let newLeftX = rightEdgeX - newWidth
@@ -806,6 +824,22 @@ final class OverlayWindowController {
         resizeDragStartWidth = nil
         resizeDragStartHeight = nil
         resizeDragStartTopLeft = nil
+    }
+
+    private func resetOverlaySizeToDefault() {
+        endResizeDrag()
+        endControlDrag()
+        userDefinedTopLeft = nil
+        userDefinedHeight = nil
+        liveResizeWidth = nil
+
+        if model.overlayStyle.attachToSource == false {
+            model.updateOverlayStyle { style in
+                style.widthRatio = OverlayStyle.default.widthRatio
+            }
+        }
+
+        positionPanels(animated: true)
     }
 
     private func startMouseTrackingIfNeeded() {
@@ -859,12 +893,7 @@ final class OverlayWindowController {
             return
         }
 
-        let interactiveFrames = [
-            scrollbarPanel.frame,
-            moveButtonPanel.frame,
-            closeButtonPanel.frame,
-            resizeButtonPanel.frame
-        ]
+        let interactiveFrames = [scrollbarPanel.frame] + leftControlButtonPanels.map(\.frame)
         guard interactiveFrames.contains(where: { $0.contains(mouseLocation) }) == false else {
             interactionState.updatePassThroughBubble(nil)
             return
@@ -905,14 +934,7 @@ final class OverlayWindowController {
     }
 
     private func overlayTrackingBounds() -> NSRect {
-        let trackedFrames = [
-            panel.frame,
-            controlsChromePanel.frame,
-            scrollbarPanel.frame,
-            moveButtonPanel.frame,
-            closeButtonPanel.frame,
-            resizeButtonPanel.frame
-        ]
+        let trackedFrames = [panel.frame] + (leftControlPanels + [scrollbarPanel]).map(\.frame)
 
         guard var trackingBounds = trackedFrames.first else {
             return .zero
@@ -993,7 +1015,7 @@ final class OverlayWindowController {
             : .normal
 
         let allContentPanels: [OverlayPanel] = [panel, controlsChromePanel]
-        let allControlPanels: [OverlayPanel] = [scrollbarPanel, moveButtonPanel, closeButtonPanel, resizeButtonPanel]
+        let allControlPanels: [OverlayPanel] = [scrollbarPanel] + leftControlButtonPanels
 
         for p in allContentPanels {
             p.level = contentLevel
@@ -1024,14 +1046,7 @@ final class OverlayWindowController {
             return
         }
 
-        let orderedPanels: [NSWindow] = [
-            panel,
-            controlsChromePanel,
-            scrollbarPanel,
-            moveButtonPanel,
-            closeButtonPanel,
-            resizeButtonPanel
-        ]
+        let orderedPanels: [NSWindow] = [panel] + (leftControlPanels + [scrollbarPanel])
 
         for orderedPanel in orderedPanels {
             orderedPanel.order(.below, relativeTo: frontmostWindowNumber)
@@ -1216,7 +1231,7 @@ private final class OverlayPanel: NSPanel {
 }
 
 private extension OverlayWindowController {
-    static let minimumOverlayHeight: Double = 105
+    static let minimumOverlayHeight: Double = Double(OverlayControlsLayout.minimumOverlayHeight)
     static let attachToSourceRefreshDelayNanoseconds: UInt64 = 120_000_000
     static let mouseTrackingActivationPadding: CGFloat = 96
     static let passThroughBubbleDiameter: CGFloat = 118


### PR DESCRIPTION
Allow taller overlay resize up to the visible screen height, add a reset-size control on the left strip, align control chrome with the overlay corner radius, and derive minimum height from the four-button panel. Keep default width capped via style.maxWidth while respecting narrow displays.