### PR TITLE
Keep subtitle overlay controls interactive in fullscreen

### DIFF
--- a/Sources/V2SApp/UI/Overlay/OverlayWindowController.swift
+++ b/Sources/V2SApp/UI/Overlay/OverlayWindowController.swift
@@ -170,13 +170,13 @@ final class OverlayWindowController {
     }
 
     private func configurePanels() {
-        configurePanel(panel, acceptsInput: false, level: .statusBar)
+        configurePanel(panel, acceptsInput: false, level: .screenSaver)
         panel.contentView = subtitleHostingView
 
-        configurePanel(controlsChromePanel, acceptsInput: false, level: .statusBar)
+        configurePanel(controlsChromePanel, acceptsInput: false, level: .screenSaver)
         controlsChromePanel.contentView = controlsChromeHostingView
 
-        let controlLevel = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 1)
+        let controlLevel = NSWindow.Level(rawValue: NSWindow.Level.screenSaver.rawValue + 1)
         configurePanel(scrollbarPanel, acceptsInput: true, level: controlLevel)
         scrollbarPanel.contentView = scrollbarHostingView
 
@@ -475,7 +475,7 @@ final class OverlayWindowController {
         )
         window.isOpaque = false
         window.backgroundColor = .clear
-        window.level = .statusBar
+        window.level = .screenSaver
         window.hasShadow = false
         window.hidesOnDeactivate = false
         window.collectionBehavior = Self.panelCollectionBehavior
@@ -1009,7 +1009,7 @@ final class OverlayWindowController {
     private func updateAttachToSourceLevels() -> Bool {
         let useHighLevel = !model.overlayStyle.attachToSource || isSourceAppFrontmost()
         let presentationChanged = lastAttachToSourceUsesHighLevel != useHighLevel
-        let contentLevel: NSWindow.Level = useHighLevel ? .statusBar : .normal
+        let contentLevel: NSWindow.Level = useHighLevel ? .screenSaver : .normal
         let controlLevel: NSWindow.Level = useHighLevel
             ? NSWindow.Level(rawValue: contentLevel.rawValue + 1)
             : .normal
@@ -1237,6 +1237,8 @@ private extension OverlayWindowController {
     static let passThroughBubbleDiameter: CGFloat = 118
     static let scrollbarRevealDistance: CGFloat = 42
     static let panelCollectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .canJoinAllApplications,
         .fullScreenAuxiliary,
         .ignoresCycle,
         .stationary


### PR DESCRIPTION
## Summary
- keep subtitle overlay panels above cross-app fullscreen content
- allow overlay controls and animation snapshots to share the fullscreen-safe window level
- preserve cross-Space and cross-application collection behavior

## Verification
- `swift test` (28 tests passing)

## Manual test
- Verify Safari/YouTube fullscreen subtitle visibility and control-button clicks on macOS.