### PR TITLE
feat(overlay): add invisible in recording toggle

### DIFF
--- a/Sources/V2SApp/Localization/AppLocalization.swift
+++ b/Sources/V2SApp/Localization/AppLocalization.swift
@@ -52,6 +52,8 @@ enum AppTextKey: String {
     case textOutline
     case outlineColor
     case attachToSource
+    case invisibleInRecording
+    case invisibleInRecordingHint
     case subtitleColor
     case backgroundColor
     case resetColors
@@ -334,6 +336,8 @@ enum AppLocalization {
             "textOutline": "Text Outline",
             "outlineColor": "Outline Color",
             "attachToSource": "Attach to Source",
+            "invisibleInRecording": "Invisible in Recording",
+            "invisibleInRecordingHint": "Subtitles stay on your screen but are left out of screen recordings, screenshots, and shared screens.",
             "subtitleColor": "Subtitle Color",
             "backgroundColor": "Background Color",
             "resetColors": "Reset Colors",
@@ -496,6 +500,8 @@ enum AppLocalization {
             "textOutline": "文字描边",
             "outlineColor": "描边颜色",
             "attachToSource": "附着到源应用",
+            "invisibleInRecording": "录屏中隐藏",
+            "invisibleInRecordingHint": "字幕仍显示在你的屏幕上，但不会出现在录屏、截图和屏幕共享中。",
             "subtitleColor": "字幕颜色",
             "backgroundColor": "背景颜色",
             "resetColors": "重置颜色",
@@ -658,6 +664,8 @@ enum AppLocalization {
             "textOutline": "Contorno del texto",
             "outlineColor": "Color del contorno",
             "attachToSource": "Vincular a la fuente",
+            "invisibleInRecording": "Invisible en grabaciones",
+            "invisibleInRecordingHint": "Los subtítulos siguen en tu pantalla, pero no aparecen en grabaciones de pantalla, capturas ni pantallas compartidas.",
             "subtitleColor": "Color del subtítulo",
             "backgroundColor": "Color de fondo",
             "resetColors": "Restablecer colores",
@@ -820,6 +828,8 @@ enum AppLocalization {
             "textOutline": "Textkontur",
             "outlineColor": "Konturfarbe",
             "attachToSource": "An Quelle anheften",
+            "invisibleInRecording": "In Aufnahmen unsichtbar",
+            "invisibleInRecordingHint": "Untertitel bleiben auf deinem Bildschirm sichtbar, erscheinen aber nicht in Bildschirmaufnahmen, Screenshots oder geteilten Bildschirmen.",
             "subtitleColor": "Untertitelfarbe",
             "backgroundColor": "Hintergrundfarbe",
             "resetColors": "Farben zurücksetzen",
@@ -982,6 +992,8 @@ enum AppLocalization {
             "textOutline": "文字の縁取り",
             "outlineColor": "縁取りの色",
             "attachToSource": "ソースに追従",
+            "invisibleInRecording": "録画に映さない",
+            "invisibleInRecordingHint": "字幕は画面に表示されたまま、画面収録・スクリーンショット・画面共有には映りません。",
             "subtitleColor": "字幕の色",
             "backgroundColor": "背景色",
             "resetColors": "色をリセット",
@@ -1144,6 +1156,8 @@ enum AppLocalization {
             "textOutline": "Contour du texte",
             "outlineColor": "Couleur du contour",
             "attachToSource": "Attacher à la source",
+            "invisibleInRecording": "Invisible à l'enregistrement",
+            "invisibleInRecordingHint": "Les sous-titres restent affichés sur votre écran mais n'apparaissent pas dans les enregistrements, les captures et les partages d'écran.",
             "subtitleColor": "Couleur des sous-titres",
             "backgroundColor": "Couleur de fond",
             "resetColors": "Réinitialiser les couleurs",
@@ -1306,6 +1320,8 @@ enum AppLocalization {
             "textOutline": "텍스트 외곽선",
             "outlineColor": "외곽선 색상",
             "attachToSource": "소스에 부착",
+            "invisibleInRecording": "녹화에 표시 안 함",
+            "invisibleInRecordingHint": "자막은 화면에 계속 표시되지만 화면 기록, 스크린샷, 화면 공유에는 나타나지 않습니다.",
             "subtitleColor": "자막 색상",
             "backgroundColor": "배경 색상",
             "resetColors": "색상 재설정",
@@ -1468,6 +1484,8 @@ enum AppLocalization {
             "textOutline": "حد النص",
             "outlineColor": "لون الحد",
             "attachToSource": "ربط بالمصدر",
+            "invisibleInRecording": "غير مرئي في التسجيل",
+            "invisibleInRecordingHint": "تبقى الترجمة ظاهرة على شاشتك لكنها لا تظهر في تسجيلات الشاشة أو لقطاتها أو مشاركة الشاشة.",
             "subtitleColor": "لون الترجمة",
             "backgroundColor": "لون الخلفية",
             "resetColors": "إعادة ضبط الألوان",
@@ -1630,6 +1648,8 @@ enum AppLocalization {
             "textOutline": "Contorno do texto",
             "outlineColor": "Cor do contorno",
             "attachToSource": "Fixar na fonte",
+            "invisibleInRecording": "Invisível em gravações",
+            "invisibleInRecordingHint": "As legendas continuam na sua tela, mas ficam de fora de gravações, capturas e compartilhamentos de tela.",
             "subtitleColor": "Cor da legenda",
             "backgroundColor": "Cor de fundo",
             "resetColors": "Redefinir cores",
@@ -1792,6 +1812,8 @@ enum AppLocalization {
             "textOutline": "Контур текста",
             "outlineColor": "Цвет контура",
             "attachToSource": "Привязать к источнику",
+            "invisibleInRecording": "Скрыть при записи",
+            "invisibleInRecordingHint": "Субтитры остаются на вашем экране, но не попадают в записи экрана, снимки и демонстрацию экрана.",
             "subtitleColor": "Цвет субтитров",
             "backgroundColor": "Цвет фона",
             "resetColors": "Сбросить цвета",

--- a/Sources/V2SApp/Models/OverlayStyle.swift
+++ b/Sources/V2SApp/Models/OverlayStyle.swift
@@ -79,6 +79,7 @@ struct OverlayStyle: Codable, Equatable {
         case translatedFirst
         case overlayScaleFactor
         case attachToSource
+        case invisibleInRecording
     }
 
     private enum LegacyCodingKeys: String, CodingKey {
@@ -102,6 +103,9 @@ struct OverlayStyle: Codable, Equatable {
     var translatedFirst: Bool
     var overlayScaleFactor: Double
     var attachToSource: Bool
+    /// Keeps the overlay on screen for the user while excluding it from screen
+    /// recordings, screenshots, and shared screens.
+    var invisibleInRecording: Bool
 
     var scaledTranslatedFontSize: Double { translatedFontSize * overlayScaleFactor }
     var scaledSourceFontSize: Double { sourceFontSize * overlayScaleFactor }
@@ -122,7 +126,8 @@ struct OverlayStyle: Codable, Equatable {
         clickThrough: true,
         translatedFirst: true,
         overlayScaleFactor: 1.0,
-        attachToSource: false
+        attachToSource: false,
+        invisibleInRecording: false
     )
 
     init(
@@ -141,7 +146,8 @@ struct OverlayStyle: Codable, Equatable {
         clickThrough: Bool,
         translatedFirst: Bool,
         overlayScaleFactor: Double = 1.0,
-        attachToSource: Bool = false
+        attachToSource: Bool = false,
+        invisibleInRecording: Bool = false
     ) {
         self.targetDisplayID = targetDisplayID
         self.topInset = topInset
@@ -159,6 +165,7 @@ struct OverlayStyle: Codable, Equatable {
         self.translatedFirst = translatedFirst
         self.overlayScaleFactor = overlayScaleFactor
         self.attachToSource = attachToSource
+        self.invisibleInRecording = invisibleInRecording
     }
 
     init(from decoder: Decoder) throws {
@@ -186,5 +193,6 @@ struct OverlayStyle: Codable, Equatable {
         translatedFirst    = try c.decodeIfPresent(Bool.self, forKey: .translatedFirst) ?? true
         overlayScaleFactor = try c.decodeIfPresent(Double.self, forKey: .overlayScaleFactor) ?? 1.0
         attachToSource = try c.decodeIfPresent(Bool.self, forKey: .attachToSource) ?? false
+        invisibleInRecording = try c.decodeIfPresent(Bool.self, forKey: .invisibleInRecording) ?? false
     }
 }

--- a/Sources/V2SApp/UI/Overlay/OverlayWindowController.swift
+++ b/Sources/V2SApp/UI/Overlay/OverlayWindowController.swift
@@ -191,6 +191,12 @@ final class OverlayWindowController {
 
         configurePanel(resetSizeButtonPanel, acceptsInput: true, level: controlLevel)
         resetSizeButtonPanel.contentView = resetSizeButtonHostingView
+
+        applyRecordingVisibility(model.overlayStyle.invisibleInRecording)
+    }
+
+    private var allPanels: [OverlayPanel] {
+        [panel, scrollbarPanel] + leftControlPanels
     }
 
     private var leftControlPanels: [OverlayPanel] {
@@ -215,6 +221,27 @@ final class OverlayWindowController {
         panel.isMovableByWindowBackground = false
         panel.collectionBehavior = Self.panelCollectionBehavior
     }
+
+    /// Excludes the overlay from screen capture while leaving it visible locally,
+    /// or restores the default capturable behaviour.
+    private func applyRecordingVisibility(_ invisibleInRecording: Bool) {
+        let sharingType = Self.sharingType(invisibleInRecording: invisibleInRecording)
+        for overlayPanel in allPanels {
+            overlayPanel.sharingType = sharingType
+        }
+        genieHideWindow?.sharingType = sharingType
+        pendingHideSnapshot?.sharingType = sharingType
+    }
+
+    private static func sharingType(invisibleInRecording: Bool) -> NSWindow.SharingType {
+        invisibleInRecording ? .none : .readOnly
+    }
+
+#if DEBUG
+    var panelSharingTypesForTesting: [NSWindow.SharingType] {
+        allPanels.map(\.sharingType)
+    }
+#endif
 
     private func bindModel() {
         model.$isOverlayVisible
@@ -253,6 +280,16 @@ final class OverlayWindowController {
             .map(\.attachToSource)
             .removeDuplicates()
             .sink { [weak self] _ in self?.scheduleAttachToSourceRefresh() }
+            .store(in: &cancellables)
+
+        model.$overlayStyle
+            .map(\.invisibleInRecording)
+            .removeDuplicates()
+            // @Published emits during willSet, so use the emitted value instead of
+            // reading model.overlayStyle here (which would still be the old style).
+            .sink { [weak self] invisibleInRecording in
+                self?.applyRecordingVisibility(invisibleInRecording)
+            }
             .store(in: &cancellables)
     }
 
@@ -479,6 +516,7 @@ final class OverlayWindowController {
         window.hasShadow = false
         window.hidesOnDeactivate = false
         window.collectionBehavior = Self.panelCollectionBehavior
+        window.sharingType = Self.sharingType(invisibleInRecording: model.overlayStyle.invisibleInRecording)
         window.contentView = imageView
 
         return window

--- a/Sources/V2SApp/UI/Settings/SettingsView.swift
+++ b/Sources/V2SApp/UI/Settings/SettingsView.swift
@@ -261,6 +261,16 @@ struct SettingsView: View {
                             .toggleStyle(.switch)
                             .labelsHidden()
                     }
+                    Divider()
+                    settingsRow(model.localized(.invisibleInRecording)) {
+                        Toggle("", isOn: invisibleInRecordingBinding)
+                            .toggleStyle(.switch)
+                            .labelsHidden()
+                    }
+                    Text(model.localized(.invisibleInRecordingHint))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 settingsCard {
                     sectionHeader(model.localized(.subtitleColor), icon: "paintpalette")
@@ -464,6 +474,10 @@ struct SettingsView: View {
 
     private var attachToSourceBinding: Binding<Bool> {
         overlayBinding(\.attachToSource)
+    }
+
+    private var invisibleInRecordingBinding: Binding<Bool> {
+        overlayBinding(\.invisibleInRecording)
     }
 
     private var translatedFontBinding: Binding<Double> {

--- a/Tests/V2STests/AppSettingsTests.swift
+++ b/Tests/V2STests/AppSettingsTests.swift
@@ -65,4 +65,42 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(decoded.interfaceLanguageID, "en")
         XCTAssertEqual(decoded.glossary, ["CEO": "Chief Executive Officer"])
     }
+
+    func testInvisibleInRecordingDefaultsToOffForSettingsSavedBeforeTheToggleExisted() throws {
+        let json = """
+        {
+          "selectedSourceID": "mic-1",
+          "inputLanguageID": "en",
+          "outputLanguageID": "ja",
+          "overlayStyle": {
+            "translatedFontSize": 20,
+            "sourceFontSize": 16,
+            "backgroundOpacity": 0.7,
+            "topInset": 12,
+            "widthRatio": 0.82,
+            "minWidth": 720,
+            "maxWidth": 1440,
+            "clickThrough": true,
+            "translatedFirst": true
+          },
+          "subtitleMode": "balanced",
+          "subtitleDisplayMode": "both",
+          "glossary": {}
+        }
+        """
+
+        let settings = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
+
+        XCTAssertFalse(settings.overlayStyle.invisibleInRecording)
+    }
+
+    func testInvisibleInRecordingSurvivesAnEncodeDecodeRoundTrip() throws {
+        var style = OverlayStyle.default
+        style.invisibleInRecording = true
+
+        let data = try JSONEncoder().encode(style)
+        let decoded = try JSONDecoder().decode(OverlayStyle.self, from: data)
+
+        XCTAssertTrue(decoded.invisibleInRecording)
+    }
 }

--- a/Tests/V2STests/OverlayWindowControllerTests.swift
+++ b/Tests/V2STests/OverlayWindowControllerTests.swift
@@ -1,0 +1,28 @@
+import AppKit
+import XCTest
+@testable import v2s
+
+final class OverlayWindowControllerTests: XCTestCase {
+    @MainActor
+    func testRecordingVisibilityUsesNewPublishedStyleValue() {
+        let settingsURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("v2s-overlay-window-controller-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: settingsURL) }
+
+        let model = AppModel(
+            settingsStore: SettingsStore(fileURL: settingsURL),
+            sourceCatalogService: SourceCatalogService()
+        )
+        let controller = OverlayWindowController(model: model, showTranscript: {})
+
+        XCTAssertTrue(controller.panelSharingTypesForTesting.allSatisfy { $0 == .readOnly })
+
+        model.updateOverlayStyle { $0.invisibleInRecording = true }
+
+        XCTAssertTrue(controller.panelSharingTypesForTesting.allSatisfy { $0 == .none })
+
+        model.updateOverlayStyle { $0.invisibleInRecording = false }
+
+        XCTAssertTrue(controller.panelSharingTypesForTesting.allSatisfy { $0 == .readOnly })
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **Invisible in Recording** toggle to the Subtitle Overlay card in Settings → Overlay. When enabled, the subtitle overlay stays visible to the user but is excluded from screen recordings, screenshots, and shared screens.

Implemented with `NSWindow.sharingType = .none` on every overlay panel.

## Changes

- **`OverlayStyle`** — new `invisibleInRecording: Bool`, default `false`, decoded via `decodeIfPresent ?? false` so existing `settings.json` files load unchanged.
- **`OverlayWindowController`** — `applyRecordingVisibility(_:)` sets `sharingType` across all seven overlay panels (subtitle, chrome, scrollbar, and the four control buttons). Applied at panel setup and re-applied through a `model.$overlayStyle` sink, so flipping the toggle takes effect on a live overlay. The genie show/hide snapshot windows get the same setting, otherwise the animation would flash into a recording.
- **`SettingsView`** — toggle row below "Attach to Source", with a caption explaining the behavior.
- **`AppLocalization`** — label and hint in all ten supported languages.
- **Tests** — old settings without the key default to off; the flag round-trips through encode/decode; the controller propagates the new value to every panel on toggle (both directions).

`swift build` succeeds, `swift test` passes 40/40.

## Verification note

The exclusion itself was **not** verified by an actual screen recording — a runtime probe failed because the dev shell lacks Screen Recording permission. The behavior rests on `sharingType = .none` being the documented API for this, still current and not deprecated in the MacOSX26.5 SDK. Worth a manual check against QuickTime or Zoom before release.

Apple's own caveat applies: a window with sharing set to `.none` cannot participate in some system services. For a borderless always-on-top panel that mainly means it also won't appear in screenshots — which matches the intent — but it is a blunt switch, not recording-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)