### PR TITLE
fix(speech): unblock Intel Macs and legacy-only speech languages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
             -scheme v2s \
             -configuration Release \
             -derivedDataPath .build/release \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
             build
 
       - name: Package app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,24 @@ jobs:
             -scheme v2s \
             -configuration Release \
             -derivedDataPath .build/release \
-            ARCHS="arm64 x86_64" \
-            ONLY_ACTIVE_ARCH=NO \
             build
+
+      - name: Verify universal binary
+        run: |
+          APP_BINARY=".build/release/Build/Products/Release/v2s.app/Contents/MacOS/v2s"
+          ARCHS="$(lipo -archs "$APP_BINARY")"
+          echo "Built architectures: $ARCHS"
+
+          for required in arm64 x86_64; do
+            case " $ARCHS " in
+              *" $required "*)
+                ;;
+              *)
+                echo "::error::Release binary is missing the $required slice"
+                exit 1
+                ;;
+            esac
+          done
 
       - name: Package app
         id: package

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ v2s asks Apple's Speech and Translation frameworks which languages the current M
 - No account, cloud backend, analytics, or telemetry.
 - v2s has no cloud backend and does not send audio or subtitle text to its own servers.
 - Translation uses Apple's on-device Translation framework. Some language packs may need to be downloaded first through System Settings.
-- On Apple silicon, v2s uses the modern on-device Speech stack when it is available.
-- On Intel Macs, the modern Speech stack is unavailable, so v2s falls back to `SFSpeechRecognizer`. It requires on-device recognition when the selected language supports it; otherwise Apple may process speech on its servers. Server-based recognition requires a network connection, is subject to Apple's service quotas, and sends captured speech to Apple under Apple's privacy terms.
+- Speech recognition prefers Apple's on-device models, and v2s picks a language variant that has a local model whenever one exists.
+- Some languages have no on-device model on a given Mac — this is common on Intel Macs, and for languages outside the modern Speech stack. Those run through Apple's server-based recognition, which needs a network connection, is subject to Apple's service quotas, and sends captured speech to Apple under Apple's privacy terms.
 
 ## Getting Started
 
@@ -73,7 +73,7 @@ v2s will ask for permissions on first use:
 ## Requirements
 
 - Speech transcription and translation require macOS 26 or newer
-- Apple silicon and Intel Macs are supported. Speech-language availability and whether recognition is on-device depend on the Mac and selected language.
+- Apple silicon and Intel Macs are supported. Which speech languages are available, and whether they recognize on device, depends on the Mac and the selected language.
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 - Menu bar app built for always-available subtitle access.
 - Live subtitle overlay with translated text on the first line and source text on the second.
 - Audio source selection for microphones and running macOS apps.
-- On-device speech transcription powered by Apple SpeechAnalyzer.
+- Speech transcription powered by Apple's Speech frameworks, preferring on-device recognition.
 - On-device translation powered by Apple Translation.
 - Transcript summarization powered by Apple Intelligence, falling back to an on-device extractive summary when Apple Intelligence is unavailable.
 - Overlay styling controls so the subtitle bar stays readable on top of real work.
@@ -50,9 +50,10 @@ v2s asks Apple's Speech and Translation frameworks which languages the current M
 ## Privacy
 
 - No account, cloud backend, analytics, or telemetry.
-- Audio and subtitle text never leave your Mac through v2s.
+- v2s has no cloud backend and does not send audio or subtitle text to its own servers.
 - Translation uses Apple's on-device Translation framework. Some language packs may need to be downloaded first through System Settings.
-- Speech recognition uses Apple's on-device Speech frameworks for the available source languages.
+- On Apple silicon, v2s uses the modern on-device Speech stack when it is available.
+- On Intel Macs, the modern Speech stack is unavailable, so v2s falls back to `SFSpeechRecognizer`. It requires on-device recognition when the selected language supports it; otherwise Apple may process speech on its servers. Server-based recognition requires a network connection, is subject to Apple's service quotas, and sends captured speech to Apple under Apple's privacy terms.
 
 ## Getting Started
 
@@ -72,6 +73,7 @@ v2s will ask for permissions on first use:
 ## Requirements
 
 - Speech transcription and translation require macOS 26 or newer
+- Apple silicon and Intel Macs are supported. Speech-language availability and whether recognition is on-device depend on the Mac and selected language.
 
 ## Building from Source
 
@@ -85,6 +87,12 @@ Or from the terminal:
 
 ```bash
 xcodebuild -project v2s.xcodeproj -scheme v2s -configuration Debug build
+```
+
+To build specifically for an Intel Mac:
+
+```bash
+swift build -c release --arch x86_64
 ```
 
 ## License

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@
 - **菜单栏常驻应用**：启动后常驻于 macOS 菜单栏，随时可打开和控制字幕。
 - **双语字幕悬浮条**：第一行显示翻译结果，第二行显示原始语音文本，便于快速对照。
 - **灵活的音频输入**：既可使用麦克风，也可只捕获某个正在运行的 macOS 应用音频。
-- **本地语音转写**：基于 Apple SpeechAnalyzer 进行语音识别。
+- **语音转写**：基于 Apple Speech 框架，优先使用本地语音识别。
 - **本地翻译**：基于 Apple Translation 框架进行翻译处理。
 - **AI 摘要**：基于 Apple Intelligence 对字幕记录进行智能摘要；当 Apple Intelligence 不可用时，自动回退到本地提取式摘要，同样可以快速掌握对话要点。
 - **可调节的字幕样式**：支持调整悬浮条样式，保证字幕在真实工作场景中依然清晰可读。
@@ -43,9 +43,10 @@ v2s 会向 Apple 的 Speech 与 Translation 框架查询当前 Mac 支持的语�
 ## 隐私保护
 
 - 无需账号，也没有云端后台、分析或遥测。
-- 音频和字幕文本不会通过 v2s 离开你的 Mac。
+- v2s 没有云端后台，也不会把音频或字幕文本发送到自己的服务器。
 - 翻译依赖 Apple 的本地 Translation 框架，部分语言包可能需要先在系统设置中下载。
-- 语音识别使用 Apple Speech 框架提供的本地识别能力，并仅面向当前设备可用的输入语言。
+- Apple 芯片 Mac 会在可用时使用新版的本地 Speech 识别能力。
+- Intel Mac 不支持新版 Speech 技术栈，因此 v2s 会回退到 `SFSpeechRecognizer`。如果所选语言支持本地识别，v2s 会强制使用本地模式；否则 Apple 可能通过服务器处理语音。在线识别需要网络连接，受 Apple 服务配额限制，并会依据 Apple 的隐私条款将捕获的语音发送给 Apple。
 
 ## 快速开始
 
@@ -65,6 +66,7 @@ v2s 会向 Apple 的 Speech 与 Translation 框架查询当前 Mac 支持的语�
 ## 环境要求
 
 - 语音转写和翻译功能需要 macOS 26 或更高版本
+- 支持 Apple 芯片和 Intel Mac；可用的语音语言以及是否能在本地识别，取决于具体 Mac 和所选语言。
 
 ## 从源码构建
 
@@ -78,6 +80,12 @@ open v2s.xcodeproj
 
 ```bash
 xcodebuild -project v2s.xcodeproj -scheme v2s -configuration Debug build
+```
+
+如需专门为 Intel Mac 构建：
+
+```bash
+swift build -c release --arch x86_64
 ```
 
 ## 许可证

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,8 +45,8 @@ v2s 会向 Apple 的 Speech 与 Translation 框架查询当前 Mac 支持的语�
 - 无需账号，也没有云端后台、分析或遥测。
 - v2s 没有云端后台，也不会把音频或字幕文本发送到自己的服务器。
 - 翻译依赖 Apple 的本地 Translation 框架，部分语言包可能需要先在系统设置中下载。
-- Apple 芯片 Mac 会在可用时使用新版的本地 Speech 识别能力。
-- Intel Mac 不支持新版 Speech 技术栈，因此 v2s 会回退到 `SFSpeechRecognizer`。如果所选语言支持本地识别，v2s 会强制使用本地模式；否则 Apple 可能通过服务器处理语音。在线识别需要网络连接，受 Apple 服务配额限制，并会依据 Apple 的隐私条款将捕获的语音发送给 Apple。
+- 语音识别优先使用 Apple 的本地模型；当某个语言存在本地模型时，v2s 会优先选用带本地模型的地区变体。
+- 部分语言在特定 Mac 上没有本地模型（Intel Mac 以及新版 Speech 技术栈未覆盖的语言尤其常见），这些语言会走 Apple 的服务器识别：需要网络连接，受 Apple 服务配额限制，并会依据 Apple 的隐私条款将捕获的语音发送给 Apple。
 
 ## 快速开始
 
@@ -66,7 +66,7 @@ v2s 会向 Apple 的 Speech 与 Translation 框架查询当前 Mac 支持的语�
 ## 环境要求
 
 - 语音转写和翻译功能需要 macOS 26 或更高版本
-- 支持 Apple 芯片和 Intel Mac；可用的语音语言以及是否能在本地识别，取决于具体 Mac 和所选语言。
+- 支持 Apple 芯片和 Intel Mac；可用的语音语言以及能否在本地识别，取决于具体 Mac 和所选语言。
 
 ## 从源码构建
 

--- a/Sources/V2SApp/App/AppModel.swift
+++ b/Sources/V2SApp/App/AppModel.swift
@@ -528,10 +528,8 @@ final class AppModel: ObservableObject {
     }
 
     func startSession() async {
-        // An earlier session can still be capturing — a recognition failure reports an
-        // error without tearing the session down — and replacing the list below would
-        // otherwise orphan it with the microphone still open.
-        stopLiveTranscriptionSessions()
+        // Finish releasing any earlier capture resources before opening replacements.
+        await stopLiveTranscriptionSessionsAndWait()
         refreshSources()
 
         let selectedSources = self.selectedSources
@@ -572,12 +570,16 @@ final class AppModel: ObservableObject {
         let config = ModeConfig.config(for: subtitleMode)
         let recognitionHints = recognitionContextualStrings()
         var startedSessions: [LiveTranscriptionSession] = []
+        var fatalSessionError: String?
 
         do {
             for source in selectedSources {
                 let sourceLanguageID = languageID(for: source)
                 let targetLanguageID = outputLanguageIDForSource(source)
                 let session = LiveTranscriptionSession()
+                // Include the session in cleanup even if start() fails after partially
+                // configuring recognition or capture resources.
+                startedSessions.append(session)
                 try await session.start(
                     source: source,
                     localeIdentifier: speechLocaleIdentifier(for: sourceLanguageID),
@@ -608,9 +610,31 @@ final class AppModel: ObservableObject {
                             sourceText: message,
                             sourceName: source.name
                         )
+                    },
+                    fatalErrorHandler: { [weak self] message in
+                        guard let self else { return }
+                        fatalSessionError = message
+                        // One selected input failing ends the logical session. Stop its
+                        // siblings before showing a global "capture stopped" state.
+                        self.stopLiveTranscriptionSessions()
+                        self.sessionState = .error
+                        self.setStatus(.custom(message))
+                        self.overlayState = OverlayPreviewState(
+                            translatedText: self.captureStoppedText,
+                            sourceText: message,
+                            sourceName: source.name
+                        )
                     }
                 )
-                startedSessions.append(session)
+
+                // A recognition task can fail while start() is suspended. Its callback
+                // runs on the main actor, so do not overwrite that error with .running.
+                guard fatalSessionError == nil else {
+                    for startedSession in startedSessions {
+                        startedSession.stop()
+                    }
+                    return
+                }
             }
 
             liveTranscriptionSessions = startedSessions
@@ -652,15 +676,32 @@ final class AppModel: ObservableObject {
     }
 
     private func stopLiveTranscriptionSessions() {
-        if liveTranscriptionSessions.isEmpty {
-            liveTranscriptionSession?.stop()
-        } else {
-            for session in liveTranscriptionSessions {
-                session.stop()
-            }
+        let sessions = takeLiveTranscriptionSessions()
+        for session in sessions {
+            session.stop()
         }
+    }
+
+    private func stopLiveTranscriptionSessionsAndWait() async {
+        let sessions = takeLiveTranscriptionSessions()
+        for session in sessions {
+            await session.stopAndWait()
+        }
+    }
+
+    /// Detaches the current sessions atomically on the main actor. The returned strong
+    /// references keep them alive until their callers have scheduled or completed stop.
+    private func takeLiveTranscriptionSessions() -> [LiveTranscriptionSession] {
+        let sessions: [LiveTranscriptionSession]
+        if liveTranscriptionSessions.isEmpty {
+            sessions = liveTranscriptionSession.map { [$0] } ?? []
+        } else {
+            sessions = liveTranscriptionSessions
+        }
+
         liveTranscriptionSessions.removeAll()
         liveTranscriptionSession = nil
+        return sessions
     }
 
     func showOverlayPreview() {

--- a/Sources/V2SApp/App/AppModel.swift
+++ b/Sources/V2SApp/App/AppModel.swift
@@ -805,9 +805,11 @@ final class AppModel: ObservableObject {
             locales.append(contentsOf: await SpeechTranscriber.supportedLocales)
         }
 
-        locales.append(contentsOf: SFSpeechRecognizer.supportedLocales().filter { locale in
-            SFSpeechRecognizer(locale: locale)?.supportsOnDeviceRecognition == true
-        })
+        // The modern Speech stack is unavailable on some Macs (notably Intel models),
+        // but the legacy recognizer can still support additional locales through
+        // Apple's speech service. Keep those locales selectable and let the session
+        // prefer on-device recognition whenever the legacy recognizer offers it.
+        locales.append(contentsOf: SFSpeechRecognizer.supportedLocales())
         return LanguageCatalog.options(for: locales)
     }
 
@@ -979,20 +981,20 @@ final class AppModel: ObservableObject {
     private func prepareSpeechRecognitionResourceIfNeeded(
         for languageID: String
     ) async -> LanguageResourceSystemSettingsDestination? {
-        guard #available(macOS 26.0, *) else {
+        guard #available(macOS 26.0, *), SpeechTranscriber.isAvailable else {
+            // There are no modern speech assets to prepare when SpeechTranscriber is
+            // unavailable. The session will use SFSpeechRecognizer instead.
+            removeLanguageResourceStatus(id: "speech:\(languageID)")
             return nil
         }
 
         let title = localized(.speechTitleFormat, languageName(for: languageID))
         let statusID = "speech:\(languageID)"
         let requestedLocale = Locale(identifier: speechLocaleIdentifier(for: languageID))
-        let resolvedLocale = SpeechTranscriber.isAvailable
-            ? await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale)
-            : nil
+        let resolvedLocale = await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale)
 
         guard let resolvedLocale else {
-            if let legacyRecognizer = SFSpeechRecognizer(locale: requestedLocale),
-               legacyRecognizer.supportsOnDeviceRecognition {
+            if SFSpeechRecognizer(locale: requestedLocale) != nil {
                 removeLanguageResourceStatus(id: statusID)
                 return nil
             }

--- a/Sources/V2SApp/App/AppModel.swift
+++ b/Sources/V2SApp/App/AppModel.swift
@@ -61,6 +61,8 @@ final class AppModel: ObservableObject {
     @Published private(set) var overlayState: OverlayPreviewState?
     @Published private(set) var languageResourceStatuses: [LanguageResourceStatus] = []
     @Published private(set) var speechLanguageOptions = LanguageCatalog.speechInput
+    /// Speech languages this Mac can recognize without sending audio to Apple.
+    @Published private(set) var onDeviceSpeechLanguageIDs: Set<String> = []
     @Published private(set) var translationLanguageOptions = LanguageCatalog.common
     @Published private(set) var translationHostConfiguration: TranslationSession.Configuration?
     @Published private(set) var transcriptEntries: [TranscriptEntry] = []
@@ -526,6 +528,10 @@ final class AppModel: ObservableObject {
     }
 
     func startSession() async {
+        // An earlier session can still be capturing — a recognition failure reports an
+        // error without tearing the session down — and replacing the list below would
+        // otherwise orphan it with the microphone still open.
+        stopLiveTranscriptionSessions()
         refreshSources()
 
         let selectedSources = self.selectedSources
@@ -751,6 +757,26 @@ final class AppModel: ObservableObject {
         speechLanguageOptions.contains(where: { $0.id == identifier }) ? identifier : "en"
     }
 
+    /// Names the selected speech languages that this Mac can only recognize through
+    /// Apple's servers, or nil when everything selected stays on device.
+    var serverSpeechRecognitionNotice: String? {
+        let selectedLanguageIDs = selectedSources.isEmpty
+            ? [inputLanguageID]
+            : selectedSources.map { languageID(for: $0) }
+
+        let serverLanguageIDs = Set(selectedLanguageIDs).subtracting(onDeviceSpeechLanguageIDs)
+        guard serverLanguageIDs.isEmpty == false else {
+            return nil
+        }
+
+        let names = serverLanguageIDs
+            .map { languageName(for: $0) }
+            .sorted()
+            .joined(separator: ", ")
+
+        return localized(.speechUsesAppleServersFormat, names)
+    }
+
     private func speechLocaleIdentifier(for languageID: String) -> String {
         speechLanguageOptions.first(where: { $0.id == languageID })?.localeIdentifier
             ?? LanguageCatalog.speechLocaleIdentifier(for: languageID)
@@ -766,7 +792,8 @@ final class AppModel: ObservableObject {
         languageCatalogRefreshTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
-            let resolvedSpeechOptions = await self.loadSupportedSpeechLanguageOptions()
+            let resolvedSpeechCatalog = await self.loadSupportedSpeechLanguageOptions()
+            let resolvedSpeechOptions = resolvedSpeechCatalog.options
             let resolvedTranslationOptions = await self.loadSupportedTranslationLanguageOptions()
             guard Task.isCancelled == false else { return }
 
@@ -775,6 +802,7 @@ final class AppModel: ObservableObject {
 
             if resolvedSpeechOptions.isEmpty == false {
                 speechLanguageOptions = resolvedSpeechOptions
+                onDeviceSpeechLanguageIDs = resolvedSpeechCatalog.onDeviceLanguageIDs
                 let supportedIDs = Set(resolvedSpeechOptions.map(\.id))
                 sourceLanguageOverrides = sourceLanguageOverrides.filter {
                     supportedIDs.contains($0.value)
@@ -799,18 +827,37 @@ final class AppModel: ObservableObject {
         }
     }
 
-    private func loadSupportedSpeechLanguageOptions() async -> [LanguageOption] {
+    private func loadSupportedSpeechLanguageOptions() async -> SpeechLanguageCatalog {
         var locales: [Locale] = []
+        // Locales that can be recognized without leaving the Mac. A language keeps only
+        // one locale, so these have to outrank the rest — otherwise a variant with no
+        // local model could win a language and push the whole session onto Apple's
+        // speech service.
+        var onDeviceLocaleIdentifiers: Set<String> = []
+
         if #available(macOS 26.0, *), SpeechTranscriber.isAvailable {
-            locales.append(contentsOf: await SpeechTranscriber.supportedLocales)
+            let modernLocales = await SpeechTranscriber.supportedLocales
+            locales.append(contentsOf: modernLocales)
+            onDeviceLocaleIdentifiers.formUnion(modernLocales.map(\.identifier))
         }
 
         // The modern Speech stack is unavailable on some Macs (notably Intel models),
         // but the legacy recognizer can still support additional locales through
         // Apple's speech service. Keep those locales selectable and let the session
         // prefer on-device recognition whenever the legacy recognizer offers it.
-        locales.append(contentsOf: SFSpeechRecognizer.supportedLocales())
-        return LanguageCatalog.options(for: locales)
+        for locale in SFSpeechRecognizer.supportedLocales() {
+            locales.append(locale)
+            if SFSpeechRecognizer(locale: locale)?.supportsOnDeviceRecognition == true {
+                onDeviceLocaleIdentifiers.insert(locale.identifier)
+            }
+        }
+
+        let options = LanguageCatalog.options(for: locales, preferring: onDeviceLocaleIdentifiers)
+        let onDeviceLanguageIDs = options
+            .filter { $0.localeIdentifier.map(onDeviceLocaleIdentifiers.contains) ?? false }
+            .map(\.id)
+
+        return SpeechLanguageCatalog(options: options, onDeviceLanguageIDs: Set(onDeviceLanguageIDs))
     }
 
     private func loadSupportedTranslationLanguageOptions() async -> [LanguageOption] {
@@ -991,10 +1038,11 @@ final class AppModel: ObservableObject {
         let title = localized(.speechTitleFormat, languageName(for: languageID))
         let statusID = "speech:\(languageID)"
         let requestedLocale = Locale(identifier: speechLocaleIdentifier(for: languageID))
-        let resolvedLocale = await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale)
+        let resolvedLocale = await LiveTranscriptionSession.modernSpeechLocale(equivalentTo: requestedLocale)
+        let hasLegacyRecognizer = SFSpeechRecognizer(locale: requestedLocale) != nil
 
         guard let resolvedLocale else {
-            if SFSpeechRecognizer(locale: requestedLocale) != nil {
+            if hasLegacyRecognizer {
                 removeLanguageResourceStatus(id: statusID)
                 return nil
             }
@@ -1022,6 +1070,10 @@ final class AppModel: ObservableObject {
             )
             removeLanguageResourceStatus(id: statusID)
         } catch is CancellationError {
+            removeLanguageResourceStatus(id: statusID)
+        } catch LanguageResourcePreparationError.unsupportedSpeechLanguage where hasLegacyRecognizer {
+            // Apple ships no modern assets for this language on this Mac. The session
+            // falls back to SFSpeechRecognizer, so this must not block starting.
             removeLanguageResourceStatus(id: statusID)
         } catch {
             upsertLanguageResourceStatus(
@@ -3016,6 +3068,11 @@ struct TranscriptEntry: Identifiable, Equatable {
     let id: UUID
     var sourceText: String
     var translatedText: String
+}
+
+private struct SpeechLanguageCatalog {
+    let options: [LanguageOption]
+    let onDeviceLanguageIDs: Set<String>
 }
 
 private enum LanguageResourcePreparationError: LocalizedError, AppLocalizableError {

--- a/Sources/V2SApp/Localization/AppLocalization.swift
+++ b/Sources/V2SApp/Localization/AppLocalization.swift
@@ -114,6 +114,7 @@ enum AppTextKey: String {
     case speechTitleFormat
     case translationTitleFormat
     case speechNotAvailableOnMacOS
+    case speechUsesAppleServersFormat
     case downloadingSpeechResources
     case translationNotSupportedPairOnMacOS
     case downloadingTranslationResources
@@ -398,6 +399,7 @@ enum AppLocalization {
             "speechTitleFormat": "Speech · %@",
             "translationTitleFormat": "Translation · %@ → %@",
             "speechNotAvailableOnMacOS": "Speech recognition is not available for this language on this macOS version.",
+            "speechUsesAppleServersFormat": "This Mac has no on-device speech model for %@, so Apple's servers handle recognition.",
             "downloadingSpeechResources": "Downloading on-device speech recognition resources...",
             "translationNotSupportedPairOnMacOS": "Translation is not supported for this language pair on this macOS version.",
             "downloadingTranslationResources": "Downloading on-device translation resources...",
@@ -562,6 +564,7 @@ enum AppLocalization {
             "speechTitleFormat": "语音识别 · %@",
             "translationTitleFormat": "翻译 · %@ → %@",
             "speechNotAvailableOnMacOS": "当前 macOS 版本不支持此语言的语音识别。",
+            "speechUsesAppleServersFormat": "本机没有%@的本地语音模型，识别将由 Apple 服务器完成。",
             "downloadingSpeechResources": "正在下载本地语音识别资源...",
             "translationNotSupportedPairOnMacOS": "当前 macOS 版本不支持此语言对的翻译。",
             "downloadingTranslationResources": "正在下载本地翻译资源...",
@@ -726,6 +729,7 @@ enum AppLocalization {
             "speechTitleFormat": "Reconocimiento de voz · %@",
             "translationTitleFormat": "Traducción · %@ → %@",
             "speechNotAvailableOnMacOS": "El reconocimiento de voz no está disponible para este idioma en esta versión de macOS.",
+            "speechUsesAppleServersFormat": "Este Mac no tiene un modelo de voz en el dispositivo para %@, así que el reconocimiento se realiza en los servidores de Apple.",
             "downloadingSpeechResources": "Descargando recursos de reconocimiento de voz en el dispositivo...",
             "translationNotSupportedPairOnMacOS": "La traducción no es compatible con este par de idiomas en esta versión de macOS.",
             "downloadingTranslationResources": "Descargando recursos de traducción en el dispositivo...",
@@ -890,6 +894,7 @@ enum AppLocalization {
             "speechTitleFormat": "Spracherkennung · %@",
             "translationTitleFormat": "Übersetzung · %@ → %@",
             "speechNotAvailableOnMacOS": "Spracherkennung ist für diese Sprache in dieser macOS-Version nicht verfügbar.",
+            "speechUsesAppleServersFormat": "Für %@ gibt es auf diesem Mac kein lokales Sprachmodell, daher übernehmen Apples Server die Erkennung.",
             "downloadingSpeechResources": "On-Device-Ressourcen für Spracherkennung werden heruntergeladen...",
             "translationNotSupportedPairOnMacOS": "Übersetzung wird für dieses Sprachpaar in dieser macOS-Version nicht unterstützt.",
             "downloadingTranslationResources": "On-Device-Übersetzungsressourcen werden heruntergeladen...",
@@ -1054,6 +1059,7 @@ enum AppLocalization {
             "speechTitleFormat": "音声認識 · %@",
             "translationTitleFormat": "翻訳 · %@ → %@",
             "speechNotAvailableOnMacOS": "この macOS バージョンでは、この言語の音声認識は利用できません。",
+            "speechUsesAppleServersFormat": "この Mac には%@のオンデバイス音声モデルがないため、認識は Apple のサーバーで行われます。",
             "downloadingSpeechResources": "オンデバイス音声認識リソースをダウンロード中...",
             "translationNotSupportedPairOnMacOS": "この macOS バージョンでは、この言語ペアの翻訳はサポートされていません。",
             "downloadingTranslationResources": "オンデバイス翻訳リソースをダウンロード中...",
@@ -1218,6 +1224,7 @@ enum AppLocalization {
             "speechTitleFormat": "Reconnaissance vocale · %@",
             "translationTitleFormat": "Traduction · %@ → %@",
             "speechNotAvailableOnMacOS": "La reconnaissance vocale n'est pas disponible pour cette langue sur cette version de macOS.",
+            "speechUsesAppleServersFormat": "Ce Mac n'a pas de modèle vocal local pour %@, la reconnaissance est donc effectuée sur les serveurs d'Apple.",
             "downloadingSpeechResources": "Téléchargement des ressources de reconnaissance vocale sur l'appareil...",
             "translationNotSupportedPairOnMacOS": "La traduction n'est pas prise en charge pour cette paire de langues sur cette version de macOS.",
             "downloadingTranslationResources": "Téléchargement des ressources de traduction sur l'appareil...",
@@ -1382,6 +1389,7 @@ enum AppLocalization {
             "speechTitleFormat": "음성 인식 · %@",
             "translationTitleFormat": "번역 · %@ → %@",
             "speechNotAvailableOnMacOS": "이 macOS 버전에서는 해당 언어의 음성 인식을 사용할 수 없습니다.",
+            "speechUsesAppleServersFormat": "이 Mac에는 %@의 온디바이스 음성 모델이 없어 인식은 Apple 서버에서 처리됩니다.",
             "downloadingSpeechResources": "온디바이스 음성 인식 리소스를 다운로드하는 중...",
             "translationNotSupportedPairOnMacOS": "이 macOS 버전에서는 해당 언어 쌍 번역을 지원하지 않습니다.",
             "downloadingTranslationResources": "온디바이스 번역 리소스를 다운로드하는 중...",
@@ -1546,6 +1554,7 @@ enum AppLocalization {
             "speechTitleFormat": "التعرّف على الكلام · %@",
             "translationTitleFormat": "الترجمة · %@ → %@",
             "speechNotAvailableOnMacOS": "التعرّف على الكلام غير متاح لهذه اللغة على هذا الإصدار من macOS.",
+            "speechUsesAppleServersFormat": "لا يتوفر على هذا الـ Mac نموذج صوتي محلي للغة %@، لذا تتم المعالجة على خوادم Apple.",
             "downloadingSpeechResources": "جارٍ تنزيل موارد التعرّف على الكلام على الجهاز...",
             "translationNotSupportedPairOnMacOS": "الترجمة غير مدعومة لهذا الزوج اللغوي على هذا الإصدار من macOS.",
             "downloadingTranslationResources": "جارٍ تنزيل موارد الترجمة على الجهاز...",
@@ -1710,6 +1719,7 @@ enum AppLocalization {
             "speechTitleFormat": "Reconhecimento de fala · %@",
             "translationTitleFormat": "Tradução · %@ → %@",
             "speechNotAvailableOnMacOS": "O reconhecimento de fala não está disponível para este idioma nesta versão do macOS.",
+            "speechUsesAppleServersFormat": "Este Mac não tem um modelo de voz no dispositivo para %@, então o reconhecimento é feito nos servidores da Apple.",
             "downloadingSpeechResources": "Baixando recursos de reconhecimento de fala no dispositivo...",
             "translationNotSupportedPairOnMacOS": "A tradução não é compatível com este par de idiomas nesta versão do macOS.",
             "downloadingTranslationResources": "Baixando recursos de tradução no dispositivo...",
@@ -1874,6 +1884,7 @@ enum AppLocalization {
             "speechTitleFormat": "Распознавание речи · %@",
             "translationTitleFormat": "Перевод · %@ → %@",
             "speechNotAvailableOnMacOS": "Распознавание речи недоступно для этого языка в этой версии macOS.",
+            "speechUsesAppleServersFormat": "На этом Mac нет локальной модели распознавания для %@, поэтому распознавание выполняется на серверах Apple.",
             "downloadingSpeechResources": "Загрузка локальных ресурсов распознавания речи...",
             "translationNotSupportedPairOnMacOS": "Перевод для этой языковой пары не поддерживается в этой версии macOS.",
             "downloadingTranslationResources": "Загрузка локальных ресурсов перевода...",

--- a/Sources/V2SApp/Models/LanguageOption.swift
+++ b/Sources/V2SApp/Models/LanguageOption.swift
@@ -120,10 +120,22 @@ enum LanguageCatalog {
         speechInput.contains(where: { $0.id == identifier }) ? identifier : "en"
     }
 
-    static func options(for locales: [Locale]) -> [LanguageOption] {
+    /// Builds the catalog options for `locales`, keeping one locale per language.
+    ///
+    /// Identifiers in `preferredIdentifiers` win their language outright. Callers use
+    /// that to keep a capable locale — one that can be recognized on device — from
+    /// losing to a variant that merely sorts earlier.
+    static func options(
+        for locales: [Locale],
+        preferring preferredIdentifiers: Set<String> = []
+    ) -> [LanguageOption] {
         options(
             for: locales.map { locale in
-                (language: locale.language, localeIdentifier: locale.identifier)
+                (
+                    language: locale.language,
+                    localeIdentifier: locale.identifier,
+                    isPreferred: preferredIdentifiers.contains(locale.identifier)
+                )
             }
         )
     }
@@ -131,18 +143,28 @@ enum LanguageCatalog {
     static func options(for languages: [Locale.Language]) -> [LanguageOption] {
         options(
             for: languages.map { language in
-                (language: language, localeIdentifier: language.minimalIdentifier)
+                (
+                    language: language,
+                    localeIdentifier: language.minimalIdentifier,
+                    isPreferred: false
+                )
             }
         )
     }
 
     private static func options(
-        for candidates: [(language: Locale.Language, localeIdentifier: String)]
+        for candidates: [(language: Locale.Language, localeIdentifier: String, isPreferred: Bool)]
     ) -> [LanguageOption] {
         var optionsByID: [String: LanguageOption] = [:]
 
         let preferredLanguages = Locale.preferredLanguages.map { Locale(identifier: $0).language }
         let sortedCandidates = candidates.sorted { lhs, rhs in
+            // Each language keeps the first identifier it sees, so preferred
+            // identifiers have to sort ahead of everything else.
+            if lhs.isPreferred != rhs.isPreferred {
+                return lhs.isPreferred
+            }
+
             let lhsRank = preferenceRank(for: lhs.language, in: preferredLanguages)
             let rhsRank = preferenceRank(for: rhs.language, in: preferredLanguages)
             if lhsRank == rhsRank {

--- a/Sources/V2SApp/Services/LiveTranscriptionSession.swift
+++ b/Sources/V2SApp/Services/LiveTranscriptionSession.swift
@@ -217,6 +217,9 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
     private var transcriptHandler: (@MainActor (RecognizedSentence) -> Void)?
     private var partialHandler: (@MainActor (DraftSegment?) -> Void)?
     private var errorHandler: (@MainActor (String) -> Void)?
+    /// Reports an unrecoverable recognition failure after this session has stopped.
+    /// The owner uses this separate callback to stop sibling sessions as well.
+    private var fatalErrorHandler: (@MainActor (String) -> Void)?
     @MainActor private var recentCommittedSentenceHistory: [RecentCommittedSentence] = []
 
     private func localized(_ key: AppTextKey, _ arguments: CVarArg...) -> String {
@@ -279,7 +282,8 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         contextualStrings: [String] = [],
         transcriptHandler: @escaping @MainActor (RecognizedSentence) -> Void,
         partialHandler: @escaping @MainActor (DraftSegment?) -> Void,
-        errorHandler: @escaping @MainActor (String) -> Void
+        errorHandler: @escaping @MainActor (String) -> Void,
+        fatalErrorHandler: @escaping @MainActor (String) -> Void
     ) async throws {
         self.transcriptHandler = transcriptHandler
         self.partialHandler = partialHandler
@@ -288,6 +292,7 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         self.activeLocaleIdentifier = localeIdentifier
         self.interfaceLanguageID = interfaceLanguageID
         self.errorHandler = errorHandler
+        self.fatalErrorHandler = fatalErrorHandler
         await MainActor.run {
             recentCommittedSentenceHistory.removeAll()
         }
@@ -315,8 +320,21 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
     }
 
     func stop() {
-        captureQueue.async { [weak self] in
-            self?.stopOnCaptureQueue()
+        // Keep the session alive until every capture resource has been released. The
+        // owner drops its references immediately after calling this method.
+        captureQueue.async { [self] in
+            stopOnCaptureQueue()
+        }
+    }
+
+    /// Stops the session and returns only after its capture queue has released all
+    /// microphone/Core Audio resources. Used before starting replacement sessions.
+    func stopAndWait() async {
+        await withCheckedContinuation { continuation in
+            captureQueue.async { [self] in
+                stopOnCaptureQueue()
+                continuation.resume()
+            }
         }
     }
 
@@ -609,14 +627,7 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
             do {
                 try self.configureSpeechRecognizer(localeIdentifier: localeIdentifier)
             } catch {
-                Task {
-                    await self.emitError(
-                        self.localized(
-                            .speechRecognitionStoppedFormat,
-                            self.localizedErrorDescription(error)
-                        )
-                    )
-                }
+                self.stopRecognitionAndSurface(error)
             }
         }
     }
@@ -1275,6 +1286,11 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
     }
 
     @MainActor
+    private func emitFatalError(_ message: String) {
+        fatalErrorHandler?(message)
+    }
+
+    @MainActor
     private func prepareCommittedSentenceForEmission(_ text: String) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.isEmpty == false else {
@@ -1801,7 +1817,7 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         stopOnCaptureQueue()
 
         Task {
-            await self.emitError(
+            await self.emitFatalError(
                 self.localized(
                     .speechRecognitionStoppedFormat,
                     self.localizedErrorDescription(error)

--- a/Sources/V2SApp/Services/LiveTranscriptionSession.swift
+++ b/Sources/V2SApp/Services/LiveTranscriptionSession.swift
@@ -65,12 +65,23 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         case stopAndSurface
     }
 
+    /// Decides what to do about a legacy recognition-task error.
+    ///
+    /// `message` is the error's localized description. Code 203 is a bucket Apple uses
+    /// for unrelated failures — the transient "Retry"/"Corrupt" faults that a restart
+    /// clears, and the server quota rejection that no amount of retrying clears — so
+    /// only the quota text earns a hard stop.
     static func legacyRecognitionErrorDisposition(
         domain: String,
-        code: Int
+        code: Int,
+        message: String = ""
     ) -> LegacyRecognitionErrorDisposition {
         guard domain == "kAFAssistantErrorDomain" else {
             return .retryWithBackoff
+        }
+
+        if message.range(of: "quota", options: .caseInsensitive) != nil {
+            return .stopAndSurface
         }
 
         switch code {
@@ -78,8 +89,6 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
             return .ignore
         case 1110:
             return .restartImmediately
-        case 203:
-            return .stopAndSurface
         default:
             return .retryWithBackoff
         }
@@ -428,6 +437,24 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         }
     }
 
+    /// Resolves `requestedLocale` to a locale the modern Speech stack actually carries.
+    ///
+    /// `SpeechTranscriber.supportedLocale(equivalentTo:)` answers with an equivalent
+    /// locale even for languages the stack does not support at all — `ru-RU` resolves
+    /// to `ru_RU` on a Mac whose supported list holds no Russian — so its answer only
+    /// counts when it appears in `supportedLocales`. Without this check the modern path
+    /// is entered for languages only the legacy recognizer can serve.
+    @available(macOS 26.0, *)
+    static func modernSpeechLocale(equivalentTo requestedLocale: Locale) async -> Locale? {
+        guard SpeechTranscriber.isAvailable,
+              let resolved = await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale) else {
+            return nil
+        }
+
+        let supportedIdentifiers = await Set(SpeechTranscriber.supportedLocales.map(\.identifier))
+        return supportedIdentifiers.contains(resolved.identifier) ? resolved : nil
+    }
+
     private func configureModernSpeechRecognizer(localeIdentifier: String) async throws -> Bool {
         guard #available(macOS 26.0, *), SpeechTranscriber.isAvailable else {
             return false
@@ -444,7 +471,7 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
     @available(macOS 26.0, *)
     private func configureSpeechAnalyzerRecognizer(localeIdentifier: String) async throws -> Bool {
         let requestedLocale = Locale(identifier: localeIdentifier)
-        guard let resolvedLocale = await SpeechTranscriber.supportedLocale(equivalentTo: requestedLocale) else {
+        guard let resolvedLocale = await Self.modernSpeechLocale(equivalentTo: requestedLocale) else {
             return false
         }
 
@@ -594,16 +621,18 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         }
     }
 
+    /// Builds a recognition request, keeping recognition on device wherever the
+    /// recognizer has a local model. Languages without one — Chinese on Intel, say —
+    /// are only served by Apple's speech service, and refusing that would leave them
+    /// with no recognition at all.
     private func makeRecognitionRequest(
-        requiresOnDeviceRecognition: Bool? = nil
+        requiresOnDeviceRecognition: Bool
     ) -> SFSpeechAudioBufferRecognitionRequest {
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
         request.taskHint = .dictation
         request.addsPunctuation = true
         request.requiresOnDeviceRecognition = requiresOnDeviceRecognition
-            ?? speechRecognizer?.supportsOnDeviceRecognition
-            ?? true
         request.contextualStrings = recognitionContextualStrings
         return request
     }
@@ -1704,7 +1733,9 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         // dispatched by the cancelled task are silently ignored.
         recognitionGeneration &+= 1
 
-        let request = makeRecognitionRequest()
+        let request = makeRecognitionRequest(
+            requiresOnDeviceRecognition: recognizer.supportsOnDeviceRecognition
+        )
 
         let task = recognizer.recognitionTask(with: request, resultHandler: makeRecognitionHandler())
 
@@ -1740,7 +1771,7 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         consecutiveRecognitionFailures += 1
 
         guard consecutiveRecognitionFailures <= recognitionRestartBackoff.count else {
-            stopRecognitionAfterRepeatedFailures(error)
+            stopRecognitionAndSurface(error)
             return
         }
 
@@ -1760,23 +1791,16 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         captureQueue.asyncAfter(deadline: .now() + delay, execute: restart)
     }
 
-    /// Tears down the legacy recognizer after it has failed to recover and reports why.
-    /// Clearing `speechRecognizer` also closes the restart paths, which all require it.
-    private func stopRecognitionAfterRepeatedFailures(_ error: Error) {
-        pendingRecognitionRestart?.cancel()
-        pendingRecognitionRestart = nil
-        recognitionGeneration &+= 1
-        recognitionRequest?.endAudio()
-        recognitionTask?.cancel()
-        recognitionTask = nil
-        recognitionRequest = nil
-        speechRecognizer = nil
-        cancelSilenceTimer()
-        cancelVADSilenceTimer()
-        resetDraftState()
+    /// Ends the session after recognition has failed for good, and reports why.
+    ///
+    /// Capture is torn down along with the recognizer: audio that nothing transcribes is
+    /// only a microphone left open, and the surfaced message tells the user the session
+    /// has stopped. `stopOnCaptureQueue` keeps `errorHandler` in place, so the message
+    /// still reaches the UI.
+    private func stopRecognitionAndSurface(_ error: Error) {
+        stopOnCaptureQueue()
 
         Task {
-            await self.emitPartialDraft(nil)
             await self.emitError(
                 self.localized(
                     .speechRecognitionStoppedFormat,
@@ -1803,7 +1827,8 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
                 let nsError = error as NSError
                 let disposition = Self.legacyRecognitionErrorDisposition(
                     domain: nsError.domain,
-                    code: nsError.code
+                    code: nsError.code,
+                    message: nsError.localizedDescription
                 )
 
                 // Codes 216/301 are intentional cancellation from our own restart/stop.
@@ -1815,14 +1840,14 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
 
                     switch disposition {
                     case .ignore:
-                        return
+                        break
                     case .restartImmediately:
                         // Code 1110 is a normal "no speech detected" timeout.
                         self.restartRecognitionTask()
                     case .stopAndSurface:
-                        // Code 203 is an exhausted Apple server quota. Retrying only
-                        // creates more rejected requests, so fail fast and tell the user.
-                        self.stopRecognitionAfterRepeatedFailures(error)
+                        // An exhausted Apple server quota. Retrying only produces more
+                        // rejected requests, so fail fast and tell the user.
+                        self.stopRecognitionAndSurface(error)
                     case .retryWithBackoff:
                         self.handleRecognitionFailure(error)
                     }

--- a/Sources/V2SApp/Services/LiveTranscriptionSession.swift
+++ b/Sources/V2SApp/Services/LiveTranscriptionSession.swift
@@ -58,6 +58,33 @@ struct RecognizedSentence: Equatable, Sendable {
 }
 
 final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
+    enum LegacyRecognitionErrorDisposition: Equatable {
+        case ignore
+        case restartImmediately
+        case retryWithBackoff
+        case stopAndSurface
+    }
+
+    static func legacyRecognitionErrorDisposition(
+        domain: String,
+        code: Int
+    ) -> LegacyRecognitionErrorDisposition {
+        guard domain == "kAFAssistantErrorDomain" else {
+            return .retryWithBackoff
+        }
+
+        switch code {
+        case 216, 301:
+            return .ignore
+        case 1110:
+            return .restartImmediately
+        case 203:
+            return .stopAndSurface
+        default:
+            return .retryWithBackoff
+        }
+    }
+
     private struct CommittedEmission {
         let text: String
         let promotionSegmentID: UUID?
@@ -140,6 +167,18 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
     /// Incremented on every restart. Handlers capture their generation at creation time
     /// and discard callbacks that arrive after a newer generation has started.
     private var recognitionGeneration: Int = 0
+    /// Consecutive recognition-task failures since the last delivered result. Restarting
+    /// immediately recovers from a one-off fault, but a persistent one — an evicted
+    /// on-device asset, an unreachable backend — would otherwise spin the task in a hot
+    /// loop, so retries are spaced out and eventually surfaced instead of hidden.
+    private var consecutiveRecognitionFailures = 0
+    private var lastRecognitionFailureTime = Date.distantPast
+    private var pendingRecognitionRestart: DispatchWorkItem?
+    /// Delay before the Nth consecutive retry. The first stays immediate so ordinary
+    /// hiccups still recover without a visible gap.
+    private let recognitionRestartBackoff: [TimeInterval] = [0, 0.5, 1.5, 3, 5]
+    /// Failures spaced further apart than this are unrelated, not a failing recognizer.
+    private let recognitionFailureWindow: TimeInterval = 60
     private var preprocessingConverter: AVAudioConverter?
     private var preprocessingConverterInputSignature: AudioFormatSignature?
     private var audioConverter: AVAudioConverter?
@@ -283,6 +322,8 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         applicationAudioCapture = nil
 
         stopModernSpeechRecognizer()
+        resetRecognitionFailureState()
+        recognitionGeneration &+= 1
         recognitionRequest?.endAudio()
         recognitionTask?.cancel()
         recognitionTask = nil
@@ -349,15 +390,13 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
             throw SessionError.unsupportedSpeechLocale(localeIdentifier)
         }
 
-        guard recognizer.supportsOnDeviceRecognition else {
-            throw SessionError.unsupportedSpeechLocale(localeIdentifier)
-        }
-
         guard recognizer.isAvailable else {
             throw SessionError.unavailableSpeechRecognizer(localeIdentifier)
         }
 
-        let request = makeRecognitionRequest()
+        let request = makeRecognitionRequest(
+            requiresOnDeviceRecognition: recognizer.supportsOnDeviceRecognition
+        )
 
         let task = recognizer.recognitionTask(with: request, resultHandler: makeRecognitionHandler())
 
@@ -365,6 +404,7 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         recognitionRequest = request
         recognitionTask = task
         recognitionBackend = .legacy
+        resetRecognitionFailureState()
         resetAudioProcessingState()
         resetLegacyTranscriptionState()
         resetModernTranscriptionState()
@@ -554,12 +594,16 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         }
     }
 
-    private func makeRecognitionRequest() -> SFSpeechAudioBufferRecognitionRequest {
+    private func makeRecognitionRequest(
+        requiresOnDeviceRecognition: Bool? = nil
+    ) -> SFSpeechAudioBufferRecognitionRequest {
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
         request.taskHint = .dictation
         request.addsPunctuation = true
-        request.requiresOnDeviceRecognition = true
+        request.requiresOnDeviceRecognition = requiresOnDeviceRecognition
+            ?? speechRecognizer?.supportsOnDeviceRecognition
+            ?? true
         request.contextualStrings = recognitionContextualStrings
         return request
     }
@@ -1506,6 +1550,8 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
 
     private func processRecognitionResult(_ result: SFSpeechRecognitionResult) {
         lastRecognitionResultTime = Date()
+        // The recognizer is delivering again — forget any earlier failures.
+        consecutiveRecognitionFailures = 0
         let transcription = result.bestTranscription
         let segments = transcription.segments
         let formattedText = transcription.formattedString as NSString
@@ -1643,6 +1689,10 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
     private func restartRecognitionTask() {
         guard let recognizer = speechRecognizer else { return }
 
+        // A restart from any source supersedes a retry still waiting on its backoff.
+        pendingRecognitionRestart?.cancel()
+        pendingRecognitionRestart = nil
+
         // Cleanly end the old request before discarding it.
         recognitionRequest?.endAudio()
         recognitionTask?.cancel()
@@ -1668,12 +1718,81 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         Task { await emitPartialDraft(nil) }
     }
 
+    private func resetRecognitionFailureState() {
+        pendingRecognitionRestart?.cancel()
+        pendingRecognitionRestart = nil
+        consecutiveRecognitionFailures = 0
+        lastRecognitionFailureTime = .distantPast
+    }
+
+    /// Recovers from a recognition-task error on captureQueue.
+    ///
+    /// Retries are spaced by `recognitionRestartBackoff` so a recognizer that fails the
+    /// instant it starts cannot loop at full speed. Once the retries are exhausted the
+    /// error reaches the UI — otherwise capture keeps running behind an overlay that
+    /// still claims to be waiting for audio.
+    private func handleRecognitionFailure(_ error: Error) {
+        let now = Date()
+        if now.timeIntervalSince(lastRecognitionFailureTime) > recognitionFailureWindow {
+            consecutiveRecognitionFailures = 0
+        }
+        lastRecognitionFailureTime = now
+        consecutiveRecognitionFailures += 1
+
+        guard consecutiveRecognitionFailures <= recognitionRestartBackoff.count else {
+            stopRecognitionAfterRepeatedFailures(error)
+            return
+        }
+
+        let delay = recognitionRestartBackoff[consecutiveRecognitionFailures - 1]
+        guard delay > 0 else {
+            restartRecognitionTask()
+            return
+        }
+
+        pendingRecognitionRestart?.cancel()
+        let restart = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingRecognitionRestart = nil
+            self.restartRecognitionTask()
+        }
+        pendingRecognitionRestart = restart
+        captureQueue.asyncAfter(deadline: .now() + delay, execute: restart)
+    }
+
+    /// Tears down the legacy recognizer after it has failed to recover and reports why.
+    /// Clearing `speechRecognizer` also closes the restart paths, which all require it.
+    private func stopRecognitionAfterRepeatedFailures(_ error: Error) {
+        pendingRecognitionRestart?.cancel()
+        pendingRecognitionRestart = nil
+        recognitionGeneration &+= 1
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        recognitionRequest = nil
+        speechRecognizer = nil
+        cancelSilenceTimer()
+        cancelVADSilenceTimer()
+        resetDraftState()
+
+        Task {
+            await self.emitPartialDraft(nil)
+            await self.emitError(
+                self.localized(
+                    .speechRecognitionStoppedFormat,
+                    self.localizedErrorDescription(error)
+                )
+            )
+        }
+    }
+
     /// Builds the result/error handler used by every recognition task.
     ///
     /// On transient errors (no speech detected, internal failure, etc.) the handler
-    /// automatically restarts recognition so the pipeline never goes silent.
-    /// Fatal configuration errors (permission denied, unsupported locale) propagate
-    /// to the UI so the user knows why things stopped.
+    /// restarts recognition so the pipeline never goes silent. Repeated failures back
+    /// off and are eventually surfaced instead of retried forever — see
+    /// `handleRecognitionFailure`. Fatal configuration errors (permission denied,
+    /// unsupported locale) propagate to the UI so the user knows why things stopped.
     private func makeRecognitionHandler() -> (SFSpeechRecognitionResult?, Error?) -> Void {
         // Capture the generation at handler-creation time. Any callback arriving
         // after a restart (which bumps recognitionGeneration) will be discarded,
@@ -1682,19 +1801,31 @@ final class LiveTranscriptionSession: NSObject, @unchecked Sendable {
         return { [weak self] result, error in
             if let error {
                 let nsError = error as NSError
-                // kAFAssistantErrorDomain 216/301 = intentional cancellation from our own
-                // restartRecognitionTask / stop calls — ignore silently.
-                let isCancellation = nsError.domain == "kAFAssistantErrorDomain"
-                    && (nsError.code == 216 || nsError.code == 301)
+                let disposition = Self.legacyRecognitionErrorDisposition(
+                    domain: nsError.domain,
+                    code: nsError.code
+                )
 
-                if isCancellation { return }
+                // Codes 216/301 are intentional cancellation from our own restart/stop.
+                if disposition == .ignore { return }
 
-                // For any other error, attempt a silent restart so recording continues.
-                // If the recogniser is truly unavailable the restart guard will bail out.
                 self?.captureQueue.async { [weak self] in
                     guard let self, self.speechRecognizer != nil,
                           self.recognitionGeneration == generation else { return }
-                    self.restartRecognitionTask()
+
+                    switch disposition {
+                    case .ignore:
+                        return
+                    case .restartImmediately:
+                        // Code 1110 is a normal "no speech detected" timeout.
+                        self.restartRecognitionTask()
+                    case .stopAndSurface:
+                        // Code 203 is an exhausted Apple server quota. Retrying only
+                        // creates more rejected requests, so fail fast and tell the user.
+                        self.stopRecognitionAfterRepeatedFailures(error)
+                    case .retryWithBackoff:
+                        self.handleRecognitionFailure(error)
+                    }
                 }
                 return
             }

--- a/Sources/V2SApp/UI/Settings/SettingsView.swift
+++ b/Sources/V2SApp/UI/Settings/SettingsView.swift
@@ -140,6 +140,12 @@ struct SettingsView: View {
                         )
                         .disabled(model.isLanguagePairLocked)
                     }
+                    if let notice = model.serverSpeechRecognitionNotice {
+                        Label(notice, systemImage: "icloud")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                     Divider()
                     SettingsControlRow(label: model.localized(.defaultSubtitleLanguage)) {
                         CommonLanguageMenuPicker(

--- a/Sources/V2SApp/UI/StatusBar/StatusBarPopoverView.swift
+++ b/Sources/V2SApp/UI/StatusBar/StatusBarPopoverView.swift
@@ -112,6 +112,12 @@ struct StatusBarPopoverView: View {
                 )
                 .disabled(model.isLanguagePairLocked)
             }
+            if let notice = model.serverSpeechRecognitionNotice {
+                Label(notice, systemImage: "icloud")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             SettingsControlRow(label: model.localized(.defaultSubtitleLanguage)) {
                 CommonLanguageMenuPicker(
                     interfaceLanguageID: model.resolvedInterfaceLanguageID,

--- a/Tests/V2STests/LanguageCatalogTests.swift
+++ b/Tests/V2STests/LanguageCatalogTests.swift
@@ -2,6 +2,28 @@ import XCTest
 @testable import v2s
 
 final class LanguageCatalogTests: XCTestCase {
+    // A language keeps a single locale, and the winner used to be whichever identifier
+    // sorted first — which can be a variant with no on-device model.
+    func testOptionsKeepPreferredLocaleForALanguage() {
+        let locales = [Locale(identifier: "fr-BE"), Locale(identifier: "fr-FR")]
+
+        let unprioritized = LanguageCatalog.options(for: locales)
+        XCTAssertEqual(unprioritized.first(where: { $0.id == "fr" })?.localeIdentifier, "fr-BE")
+
+        let prioritized = LanguageCatalog.options(for: locales, preferring: ["fr-FR"])
+        XCTAssertEqual(prioritized.first(where: { $0.id == "fr" })?.localeIdentifier, "fr-FR")
+    }
+
+    func testOptionsIgnorePreferenceForOtherLanguages() {
+        let options = LanguageCatalog.options(
+            for: [Locale(identifier: "fr-BE"), Locale(identifier: "fr-FR"), Locale(identifier: "it-CH")],
+            preferring: ["fr-FR"]
+        )
+
+        XCTAssertEqual(options.first(where: { $0.id == "it" })?.localeIdentifier, "it-CH")
+        XCTAssertEqual(options.filter { $0.id == "fr" }.count, 1)
+    }
+
     func testSpeechInputLanguagesUseSpeechAnalyzerSupportedDefaults() {
         let expectedLocaleIdentifiers: [String: String] = [
             "en": "en-US",

--- a/Tests/V2STests/LiveTranscriptionSessionTests.swift
+++ b/Tests/V2STests/LiveTranscriptionSessionTests.swift
@@ -12,7 +12,27 @@ final class LiveTranscriptionSessionTests: XCTestCase {
     }
 
     func testLegacyRecognitionErrorDispositionStopsAfterServerQuotaError() {
-        XCTAssertEqual(disposition(code: 203), .stopAndSurface)
+        XCTAssertEqual(
+            disposition(
+                code: 203,
+                message: "Quota limit reached for resource: speech_api, actor_type: user"
+            ),
+            .stopAndSurface
+        )
+    }
+
+    // Code 203 also covers transient faults that a restart clears, so the code alone
+    // must not end the session.
+    func testLegacyRecognitionErrorDispositionRetriesNonQuotaCode203() {
+        XCTAssertEqual(disposition(code: 203, message: "Retry"), .retryWithBackoff)
+        XCTAssertEqual(disposition(code: 203, message: "Corrupt"), .retryWithBackoff)
+    }
+
+    func testLegacyRecognitionErrorDispositionStopsOnQuotaRegardlessOfCode() {
+        XCTAssertEqual(
+            disposition(code: 1700, message: "Quota limit reached for resource: speech_api"),
+            .stopAndSurface
+        )
     }
 
     func testLegacyRecognitionErrorDispositionBacksOffOtherErrors() {
@@ -26,12 +46,25 @@ final class LiveTranscriptionSessionTests: XCTestCase {
         )
     }
 
+    // A cancellation code from another domain is a real failure, not our own teardown.
+    func testLegacyRecognitionErrorDispositionDoesNotIgnoreForeignDomains() {
+        XCTAssertEqual(
+            LiveTranscriptionSession.legacyRecognitionErrorDisposition(
+                domain: NSURLErrorDomain,
+                code: 216
+            ),
+            .retryWithBackoff
+        )
+    }
+
     private func disposition(
-        code: Int
+        code: Int,
+        message: String = ""
     ) -> LiveTranscriptionSession.LegacyRecognitionErrorDisposition {
         LiveTranscriptionSession.legacyRecognitionErrorDisposition(
             domain: "kAFAssistantErrorDomain",
-            code: code
+            code: code,
+            message: message
         )
     }
 }

--- a/Tests/V2STests/LiveTranscriptionSessionTests.swift
+++ b/Tests/V2STests/LiveTranscriptionSessionTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import v2s
+
+final class LiveTranscriptionSessionTests: XCTestCase {
+    func testLegacyRecognitionErrorDispositionIgnoresCancellationErrors() {
+        XCTAssertEqual(disposition(code: 216), .ignore)
+        XCTAssertEqual(disposition(code: 301), .ignore)
+    }
+
+    func testLegacyRecognitionErrorDispositionRestartsAfterSilence() {
+        XCTAssertEqual(disposition(code: 1110), .restartImmediately)
+    }
+
+    func testLegacyRecognitionErrorDispositionStopsAfterServerQuotaError() {
+        XCTAssertEqual(disposition(code: 203), .stopAndSurface)
+    }
+
+    func testLegacyRecognitionErrorDispositionBacksOffOtherErrors() {
+        XCTAssertEqual(disposition(code: 999), .retryWithBackoff)
+        XCTAssertEqual(
+            LiveTranscriptionSession.legacyRecognitionErrorDisposition(
+                domain: NSURLErrorDomain,
+                code: NSURLErrorNotConnectedToInternet
+            ),
+            .retryWithBackoff
+        )
+    }
+
+    private func disposition(
+        code: Int
+    ) -> LiveTranscriptionSession.LegacyRecognitionErrorDisposition {
+        LiveTranscriptionSession.legacyRecognitionErrorDisposition(
+            domain: "kAFAssistantErrorDomain",
+            code: code
+        )
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="v2s — live bilingual subtitles for meetings, calls, streams, and videos on macOS. On-device speech and translation, menu bar workflow, zero cloud." />
+  <meta name="description" content="v2s — live bilingual subtitles for meetings, calls, streams, and videos on macOS. Local-first speech, on-device translation, and a lightweight menu bar workflow." />
   <meta name="theme-color" content="#0a0c10" />
   <title>v2s — Live bilingual subtitles for macOS</title>
   <link rel="icon" href="assets/app-icon.png" type="image/png" />
@@ -69,10 +69,10 @@
       <div class="container hero-grid">
         <div class="hero-copy reveal">
           <div class="badge-row">
-            <span class="badge" data-i18n="hero.badgeOnDevice">100% on-device</span>
+            <span class="badge" data-i18n="hero.badgeOnDevice">Local-first</span>
             <span class="badge badge-muted" data-i18n="hero.badgeMac">macOS 26+</span>
           </div>
-          <h1 data-i18n="hero.title">v2s: Live bilingual subtitles, never uploaded to the cloud.</h1>
+          <h1 data-i18n="hero.title">v2s: Live bilingual subtitles, private by design.</h1>
           <p class="hero-lead" data-i18n="hero.lead">
             v2s turns microphone or app audio into a clean two-line subtitle bar for meetings, calls, streams, and videos.
             Hear the original language, read the translation, and stay on the window you already use.
@@ -121,7 +121,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 3v2m0 14v2M5.6 5.6l1.4 1.4m9.9 9.9 1.4 1.4M3 12h2m14 0h2M5.6 18.4l1.4-1.4m9.9-9.9 1.4-1.4"/><circle cx="12" cy="12" r="4"/></svg>
           </div>
           <h3 data-i18n="highlights.h1Title">Private by design</h3>
-          <p data-i18n="highlights.h1Body">No account, analytics, or cloud backend. Audio and subtitles stay on your Mac through Apple's on-device frameworks.</p>
+          <p data-i18n="highlights.h1Body">No account, analytics, or v2s cloud backend. Translation is on-device; speech stays local whenever the selected language supports it.</p>
         </article>
         <article class="highlight-card reveal reveal-delay">
           <div class="highlight-icon" aria-hidden="true">
@@ -259,11 +259,11 @@
         </div>
         <div>
           <p class="eyebrow" data-i18n="privacy.eyebrow">Privacy</p>
-          <h2 data-i18n="privacy.title">Your meeting stays on your machine.</h2>
+          <h2 data-i18n="privacy.title">Local-first, with transparent fallbacks.</h2>
           <ul class="check-list">
             <li data-i18n="privacy.li1">No account, cloud backend, analytics, or telemetry</li>
-            <li data-i18n="privacy.li2">Audio and subtitle text never leave your Mac through v2s</li>
-            <li data-i18n="privacy.li3">Speech and translation use Apple's on-device frameworks</li>
+            <li data-i18n="privacy.li2">v2s never sends audio or subtitle text to its own servers</li>
+            <li data-i18n="privacy.li3">Translation is on-device; Intel speech may use Apple's service when no local model exists</li>
             <li data-i18n="privacy.li4">Permissions requested only for speech, mic, or app audio capture</li>
           </ul>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -263,7 +263,7 @@
           <ul class="check-list">
             <li data-i18n="privacy.li1">No account, cloud backend, analytics, or telemetry</li>
             <li data-i18n="privacy.li2">v2s never sends audio or subtitle text to its own servers</li>
-            <li data-i18n="privacy.li3">Translation is on-device; Intel speech may use Apple's service when no local model exists</li>
+            <li data-i18n="privacy.li3">Translation is on-device; speech uses Apple's service only for languages with no local model</li>
             <li data-i18n="privacy.li4">Permissions requested only for speech, mic, or app audio capture</li>
           </ul>
         </div>

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -124,7 +124,7 @@
         title: "Local-first, with transparent fallbacks.",
         li1: "No account, cloud backend, analytics, or telemetry",
         li2: "v2s never sends audio or subtitle text to its own servers",
-        li3: "Translation is on-device; Intel speech may use Apple's service when no local model exists",
+        li3: "Translation is on-device; speech uses Apple's service only for languages with no local model",
         li4: "Permissions requested only for speech, mic, or app audio capture",
       },
       quickStart: {
@@ -271,7 +271,7 @@
         title: "本地优先，回退逻辑透明。",
         li1: "无需账号、云端后台、分析或遥测",
         li2: "v2s 不会把音频或字幕文本发送到自己的服务器",
-        li3: "翻译在本地完成；Intel Mac 没有本地语音模型时可能使用 Apple 服务",
+        li3: "翻译在本地完成；只有在语言没有本地模型时，语音识别才会使用 Apple 服务",
         li4: "仅在需要时请求语音、麦克风或应用音频捕获权限",
       },
       quickStart: {

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -6,7 +6,7 @@
       meta: {
         title: "v2s — Live bilingual subtitles for macOS",
         description:
-          "v2s — live bilingual subtitles for meetings, calls, streams, and videos on macOS. On-device speech and translation, menu bar workflow, zero cloud.",
+          "v2s — live bilingual subtitles for meetings, calls, streams, and videos on macOS. Local-first speech, on-device translation, and a lightweight menu bar workflow.",
       },
       a11y: {
         skip: "Skip to content",
@@ -26,9 +26,9 @@
         download: "Download",
       },
       hero: {
-        badgeOnDevice: "100% on-device",
+        badgeOnDevice: "Local-first",
         badgeMac: "macOS 26+",
-        title: "v2s: Live bilingual subtitles, never uploaded to the cloud.",
+        title: "v2s: Live bilingual subtitles, private by design.",
         lead:
           "v2s turns microphone or app audio into a clean two-line subtitle bar for meetings, calls, streams, and videos. Hear the original language, read the translation, and stay on the window you already use.",
         ctaDownload: "Download for macOS",
@@ -42,7 +42,7 @@
       highlights: {
         h1Title: "Private by design",
         h1Body:
-          "No account, analytics, or cloud backend. Audio and subtitles stay on your Mac through Apple's on-device frameworks.",
+          "No account, analytics, or v2s cloud backend. Translation is on-device; speech stays local whenever the selected language supports it.",
         h2Title: "Menu bar first",
         h2Body:
           "Always one click away. Start, stop, and tune languages without leaving your meeting or player fullscreen.",
@@ -121,10 +121,10 @@
       },
       privacy: {
         eyebrow: "Privacy",
-        title: "Your meeting stays on your machine.",
+        title: "Local-first, with transparent fallbacks.",
         li1: "No account, cloud backend, analytics, or telemetry",
-        li2: "Audio and subtitle text never leave your Mac through v2s",
-        li3: "Speech and translation use Apple's on-device frameworks",
+        li2: "v2s never sends audio or subtitle text to its own servers",
+        li3: "Translation is on-device; Intel speech may use Apple's service when no local model exists",
         li4: "Permissions requested only for speech, mic, or app audio capture",
       },
       quickStart: {
@@ -166,7 +166,7 @@
       meta: {
         title: "v2s — macOS 实时双语字幕",
         description:
-          "v2s — 适用于会议、通话、直播和视频的 macOS 实时双语字幕。本地语音与翻译、菜单栏工作流、零云端。",
+          "v2s — 适用于会议、通话、直播和视频的 macOS 实时双语字幕。本地优先语音识别、本地翻译与轻量菜单栏工作流。",
       },
       a11y: {
         skip: "跳到正文",
@@ -186,9 +186,9 @@
         download: "下载",
       },
       hero: {
-        badgeOnDevice: "100% 本地处理",
+        badgeOnDevice: "本地优先",
         badgeMac: "macOS 26+",
-        title: "v2s: 实时双语字幕，绝不上传云端。",
+        title: "v2s：重视隐私的实时双语字幕。",
         lead:
           "v2s 将麦克风或应用音频转换为简洁的双行字幕条，适用于会议、通话、直播和视频。一边听原语言，一边读翻译，无需切换窗口。",
         ctaDownload: "下载 macOS 版",
@@ -201,7 +201,7 @@
       },
       highlights: {
         h1Title: "隐私优先",
-        h1Body: "无需账号、分析或云端后台。音频与字幕通过 Apple 本地框架留在你的 Mac 上。",
+        h1Body: "无需账号、分析或 v2s 云端后台。翻译在本地完成；所选语言支持时，语音识别也在本地完成。",
         h2Title: "菜单栏即用",
         h2Body: "始终一键可达。开始、停止与语言设置，无需离开会议或播放器全屏。",
         h3Title: "自选音频源",
@@ -268,10 +268,10 @@
       },
       privacy: {
         eyebrow: "隐私保护",
-        title: "会议内容留在你的机器上。",
+        title: "本地优先，回退逻辑透明。",
         li1: "无需账号、云端后台、分析或遥测",
-        li2: "音频与字幕文本不会通过 v2s 离开 Mac",
-        li3: "语音与翻译使用 Apple 本地框架",
+        li2: "v2s 不会把音频或字幕文本发送到自己的服务器",
+        li3: "翻译在本地完成；Intel Mac 没有本地语音模型时可能使用 Apple 服务",
         li4: "仅在需要时请求语音、麦克风或应用音频捕获权限",
       },
       quickStart: {

--- a/v2s.xcodeproj/project.pbxproj
+++ b/v2s.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 		A00000000000000000000017 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = arm64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
Fixes the Intel Mac blocker reported in #23, plus three problems that surfaced while verifying the fix on real hardware.

## The original bug

The modern SpeechAnalyzer stack is unavailable on Intel, so `prepareSpeechRecognitionResourceIfNeeded` always landed an error status and disabled session start — even though `SFSpeechRecognizer` works there. The modern asset preparation is now gated on the stack actually being usable, and the legacy recognizer handles what it can.

## What verification turned up

**`supportedLocale(equivalentTo:)` lies.** It answers with an equivalent locale even for languages the modern stack does not carry — `ru-RU` resolves to `ru_RU` on a Mac whose supported list has no Russian. Probed on Apple silicon / macOS 26:

```
ru-RU -> ru_RU, AssetInventory.status = unsupported
th-TH -> th_TH, AssetInventory.status = unsupported
ar-SA -> ar_SA, AssetInventory.status = unsupported
```

So the legacy fallback branch never ran, and asset preparation blocked start with "resources are not supported" — issue #23's exact symptom, reproduced on Apple silicon for every legacy-only language. Resolution now requires membership in `supportedLocales`, and a missing modern asset falls through to the legacy recognizer instead of blocking. On this Mac: **36 languages offered, 11 modern, 25 legacy, 0 blocked** (was 25 blocked).

**Error 203 is a bucket code.** Apple reuses it for transient "Retry"/"Corrupt" faults as well as the server quota rejection, so stopping on the code alone ended sessions that used to recover on their own. Only the quota message stops now; everything else backs off.

**A language could be won by a locale with no local model.** Dropping the on-device filter left the winner as whichever identifier sorted first. `LanguageCatalog.options(for:preferring:)` now ranks locales that can run on device ahead of the rest.

**A surfaced error left the microphone open.** Recognition failure reported an error without tearing the session down, and starting again replaced the session list without stopping the old sessions. Recognition failure now stops the session, and `startSession` stops whatever is still running first.

## Also in here

- Retry storm: the recognition task restarted on every error with no delay (~314 requests/minute in the reporter's field data). Retries are now spaced `[0, 0.5, 1.5, 3, 5]`s, and a recognizer that stops recovering reports the failure instead of looping silently behind a "Waiting for audio…" overlay.
- Server-based recognition is disclosed in the app, not just the README: the settings and menu bar language pickers say when the selected language has no local model (all 10 interface languages).
- Universal release builds via `ARCHS_STANDARD` in the project, with a `lipo -archs` check in the release workflow.

## Verification

`swift build` and 49 tests pass (was 40). A full `xcodebuild -configuration Release` produces a universal binary — `lipo -archs` reports `x86_64 arm64` — confirming the x86_64 slices the reporter described. Locale resolution and asset status were probed against the real Speech framework on Apple silicon / macOS 26.

Not verified: the new UI caption was only compile-checked, not seen running, and the Intel behavior itself still needs confirmation from someone on that hardware — @dracpet, this branch would be worth a build if you have a moment.

Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)
