### PR TITLE
feat(release): publish a Homebrew cask on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,3 +141,55 @@ jobs:
               --generate-notes \
               --verify-tag
           fi
+
+      - name: Update Homebrew tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_REPO: franklioxygen/homebrew-v2s
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "HOMEBREW_TAP_TOKEN is not set; skipping Homebrew tap update."
+            exit 0
+          fi
+
+          SHA256="$(awk '{print $1}' "${{ steps.package.outputs.checksum }}")"
+          if [ -z "$SHA256" ]; then
+            echo "::error::Could not read the release checksum"
+            exit 1
+          fi
+
+          git clone --depth 1 \
+            "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
+
+          # Republishing an older tag must not downgrade the cask users install.
+          TAPPED_VERSION=""
+          if [ -f tap/Casks/v2s.rb ]; then
+            TAPPED_VERSION="$(sed -n 's/^  version "\(.*\)"$/\1/p' tap/Casks/v2s.rb | head -1)"
+          fi
+          if [ -n "$TAPPED_VERSION" ] && [ "$TAPPED_VERSION" != "$VERSION" ]; then
+            NEWEST="$(printf '%s\n%s\n' "$TAPPED_VERSION" "$VERSION" | sort -V | tail -1)"
+            if [ "$NEWEST" != "$VERSION" ]; then
+              echo "Tap already has ${TAPPED_VERSION}, which is newer than ${VERSION}; skipping."
+              exit 0
+            fi
+          fi
+
+          mkdir -p tap/Casks
+          sed \
+            -e "s/__VERSION__/${VERSION}/g" \
+            -e "s/__SHA256__/${SHA256}/g" \
+            packaging/homebrew/v2s.rb.template > tap/Casks/v2s.rb
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/v2s.rb
+
+          if git diff --cached --quiet; then
+            echo "Cask already up to date."
+            exit 0
+          fi
+
+          git commit -m "v2s ${VERSION}"
+          git push

--- a/README.md
+++ b/README.md
@@ -57,12 +57,37 @@ v2s asks Apple's Speech and Translation frameworks which languages the current M
 
 ## Getting Started
 
+### Install with Homebrew
+
+```bash
+brew install --cask franklioxygen/v2s/v2s
+```
+
+v2s is not notarized by Apple yet, so macOS quarantines it after download. Clear
+the flag once, then launch the app:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/v2s.app
+```
+
+If you already have `v2s.app` in your Applications folder from a manual install,
+add `--adopt` so Homebrew takes over the existing copy instead of refusing to
+overwrite it.
+
+Updates arrive through the in-app updater. To let Homebrew handle them instead,
+run `brew upgrade --cask --greedy v2s`.
+
+### Install manually
+
 1. Download the latest `.app.zip` from [Releases](https://github.com/franklioxygen/v2s/releases).
 2. Unzip and move `v2s.app` to your Applications folder.
-3. Launch v2s — it appears as an icon in your menu bar.
-4. Select an input source (a running app or microphone).
-5. Choose your input and subtitle languages.
-6. Click **Start**.
+
+### First run
+
+1. Launch v2s — it appears as an icon in your menu bar.
+2. Select an input source (a running app or microphone).
+3. Choose your input and subtitle languages.
+4. Click **Start**.
 
 v2s will ask for permissions on first use:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,12 +50,36 @@ v2s 会向 Apple 的 Speech 与 Translation 框架查询当前 Mac 支持的语�
 
 ## 快速开始
 
+### 使用 Homebrew 安装
+
+```bash
+brew install --cask franklioxygen/v2s/v2s
+```
+
+v2s 尚未通过 Apple 公证，macOS 会在下载后将其隔离。执行一次下面的命令清除隔离标记，
+之后即可正常启动：
+
+```bash
+xattr -dr com.apple.quarantine /Applications/v2s.app
+```
+
+如果之前手动安装过、`Applications` 里已经有 `v2s.app`，请加上 `--adopt`，让
+Homebrew 接管现有副本，而不是因为无法覆盖而报错。
+
+更新由应用内的更新器负责。如果希望改由 Homebrew 管理更新，可以运行
+`brew upgrade --cask --greedy v2s`。
+
+### 手动安装
+
 1. 从 [Releases](https://github.com/franklioxygen/v2s/releases) 页面下载最新的 `.app.zip`。
 2. 解压后将 `v2s.app` 移动到 `Applications` 文件夹。
-3. 启动 v2s，它会以图标形式出现在菜单栏中。
-4. 选择输入源：麦克风或某个正在运行的应用。
-5. 选择输入语言和字幕语言。
-6. 点击 **Start**。
+
+### 首次运行
+
+1. 启动 v2s，它会以图标形式出现在菜单栏中。
+2. 选择输入源：麦克风或某个正在运行的应用。
+3. 选择输入语言和字幕语言。
+4. 点击 **Start**。
 
 首次使用时，v2s 会请求以下权限：
 

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,54 @@
+# Homebrew distribution
+
+Users install v2s with:
+
+```bash
+brew install --cask franklioxygen/v2s/v2s
+```
+
+That name resolves to the cask `Casks/v2s.rb` in the tap repository
+`franklioxygen/homebrew-v2s`. Homebrew taps it automatically on first install.
+
+`v2s.rb.template` in this directory is the source of truth for that cask. The
+`Update Homebrew tap` step in `.github/workflows/release.yml` fills in
+`__VERSION__` and `__SHA256__` from the release it just published, writes the
+result to `Casks/v2s.rb` in the tap, and pushes.
+
+Because the workflow can also be dispatched manually against an existing tag,
+that step first compares the version already in the tap against the one being
+published and skips the push if the tap is newer — re-running the workflow for
+an old tag must not downgrade what `brew install` hands users. Publishing the
+same version again is allowed, so a rebuilt asset can correct a checksum.
+
+## Setup
+
+The tap repository exists and is seeded with the cask for v0.3.35, so
+`brew install --cask franklioxygen/v2s/v2s` already works. One step is left
+before releases update it automatically:
+
+- Create a fine-grained personal access token scoped to `homebrew-v2s` with
+  `Contents: Read and write` permission, and add it to this repository as the
+  `HOMEBREW_TAP_TOKEN` secret. Without it the release workflow logs a skip
+  instead of failing.
+
+To regenerate the cask by hand, from a checkout of the tap:
+
+```bash
+VERSION=0.3.35
+SHA256=$(curl -fsSL "https://github.com/franklioxygen/v2s/releases/download/v${VERSION}/v2s-${VERSION}.sha256" | awk '{print $1}')
+sed -e "s/__VERSION__/${VERSION}/g" -e "s/__SHA256__/${SHA256}/g" \
+  ../v2s/packaging/homebrew/v2s.rb.template > Casks/v2s.rb
+```
+
+## Notarization
+
+The release build is ad-hoc signed (`CODE_SIGN_IDENTITY = "-"`), so macOS
+quarantines the app and refuses to launch it until the user runs
+`xattr -dr com.apple.quarantine /Applications/v2s.app`. Homebrew 6 removed the
+`--no-quarantine` install flag, so there is no way to avoid this from the cask.
+
+Signing with a Developer ID certificate and notarizing in the release workflow
+would remove that step, and is also a prerequisite for `brew audit --new`, which
+currently fails with "not signed by a distributor that meets the system
+Gatekeeper requirements" — the check that gates submission to the official
+`homebrew/cask` repository.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -22,14 +22,13 @@ same version again is allowed, so a rebuilt asset can correct a checksum.
 
 ## Setup
 
-The tap repository exists and is seeded with the cask for v0.3.35, so
-`brew install --cask franklioxygen/v2s/v2s` already works. One step is left
-before releases update it automatically:
+Setup is complete: the tap repository is seeded with the cask for v0.3.35, and
+the `HOMEBREW_TAP_TOKEN` secret is set, so releases update the tap on their own.
 
-- Create a fine-grained personal access token scoped to `homebrew-v2s` with
-  `Contents: Read and write` permission, and add it to this repository as the
-  `HOMEBREW_TAP_TOKEN` secret. Without it the release workflow logs a skip
-  instead of failing.
+That secret is a fine-grained personal access token scoped to `homebrew-v2s`
+with `Contents: Read and write` permission. If it is ever removed or expires,
+the release workflow logs a skip instead of failing, and the tap simply stops
+receiving new versions until it is replaced.
 
 To regenerate the cask by hand, from a checkout of the tap:
 

--- a/packaging/homebrew/v2s.rb.template
+++ b/packaging/homebrew/v2s.rb.template
@@ -1,0 +1,27 @@
+cask "v2s" do
+  version "__VERSION__"
+  sha256 "__SHA256__"
+
+  url "https://github.com/franklioxygen/v2s/releases/download/v#{version}/v2s-#{version}.app.zip"
+  name "v2s"
+  desc "Live bilingual subtitles for meetings, calls, streams, and videos"
+  homepage "https://github.com/franklioxygen/v2s"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :sequoia
+
+  app "v2s.app"
+
+  zap trash: [
+    "~/Library/Application Support/v2s",
+    "~/Library/Caches/com.franklioxygen.v2s",
+    "~/Library/HTTPStorages/com.franklioxygen.v2s",
+    "~/Library/Preferences/com.franklioxygen.v2s.plist",
+    "~/Library/Saved Application State/com.franklioxygen.v2s.savedState",
+  ]
+end


### PR DESCRIPTION
Adds `brew` as an install path for v2s:

```bash
brew install --cask franklioxygen/v2s/v2s
```

macOS GUI apps need a **Cask** rather than a Formula, and casks must live in a tap, so the cask is served from the new [franklioxygen/homebrew-v2s](https://github.com/franklioxygen/homebrew-v2s) repository. That tap is already seeded with v0.3.35, so the command above works today.

## What's here

- `packaging/homebrew/v2s.rb.template` — the source of truth for the cask, with `__VERSION__` / `__SHA256__` placeholders.
- A `Update Homebrew tap` step in the release workflow that renders the template with the version and checksum it just published and pushes it to the tap.
- Install instructions in both READMEs.
- `packaging/homebrew/README.md` documenting the setup and the notarization gap.

## Not downgrading the tap

The release workflow also accepts a `workflow_dispatch` against an existing tag. Left alone, dispatching an old tag would rewrite the cask to that older version and silently downgrade what `brew install` hands users. The step now compares against the version already in the tap and skips the push when the tap is newer.

`sort -V` does the comparison — a string compare gets `0.3.9` vs `0.3.35` and `0.10.0` vs `0.3.35` backwards. Verified across newer / equal / older / fresh-tap cases.

Equal versions still proceed, so a rebuilt asset can correct a checksum; the existing `git diff --cached --quiet` check no-ops when the rendered cask is byte-identical.

## Notarization caveat

The release build is ad-hoc signed (`CODE_SIGN_IDENTITY = "-"`), so macOS quarantines the app and refuses to launch it until the user runs:

```bash
xattr -dr com.apple.quarantine /Applications/v2s.app
```

Homebrew 6 removed the `--no-quarantine` install flag, so this cannot be avoided from the cask side. It is documented in both READMEs.

This is also what blocks submission to the official `homebrew/cask` repo — `brew audit --cask --online --new` fails with *"not signed by a distributor that meets the system Gatekeeper requirements"*. Notability is not the problem (377 stars / 40 forks clears the 75-star / 30-fork bar). Signing with a Developer ID certificate and notarizing in CI would clear both the manual `xattr` step and the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)