### PR TITLE
fix(ui): pin the status bar popover to the system appearance

### DIFF
--- a/Sources/V2SApp/UI/Shared/QuickSettingsControls.swift
+++ b/Sources/V2SApp/UI/Shared/QuickSettingsControls.swift
@@ -143,7 +143,7 @@ struct SourceMultiSelectPicker: View {
                 .frame(minWidth: 180, minHeight: 32, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color(nsColor: .controlColor))
+                    .fill(.fill.quaternary)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)

--- a/Sources/V2SApp/UI/StatusBar/StatusBarController.swift
+++ b/Sources/V2SApp/UI/StatusBar/StatusBarController.swift
@@ -47,6 +47,16 @@ final class StatusBarController: NSObject, NSPopoverDelegate {
         popover.delegate = self
         popover.behavior = .transient
         popover.contentSize = NSSize(width: 340, height: 500)
+        applySystemAppearance()
+    }
+
+    /// Pins the popover to the system light/dark appearance.
+    ///
+    /// Left unset, the popover's glass backdrop derives its appearance from
+    /// whatever sits behind it, so a bright wallpaper makes the content draw in
+    /// light mode while the system is in dark mode.
+    private func applySystemAppearance() {
+        popover.appearance = NSApp.effectiveAppearance
     }
 
     private func bindModel() {
@@ -95,6 +105,7 @@ final class StatusBarController: NSObject, NSPopoverDelegate {
             popover.performClose(sender)
         } else {
             model.refreshSources()
+            applySystemAppearance()
             popover.contentViewController = NSHostingController(
                 rootView: StatusBarPopoverView(
                     model: model,

--- a/Sources/V2SApp/UI/StatusBar/StatusBarPopoverView.swift
+++ b/Sources/V2SApp/UI/StatusBar/StatusBarPopoverView.swift
@@ -23,6 +23,7 @@ struct StatusBarPopoverView: View {
             footerSection
         }
         .frame(width: 340)
+        .background(.regularMaterial)
         .environment(\.locale, model.interfaceLocale)
         .v2sTranslationHost(model: model)
         .onChange(of: model.sessionState) { _, newState in
@@ -223,7 +224,7 @@ struct StatusBarPopoverView: View {
             if model.selectedSources.isEmpty == false {
                 Text(model.selectedSourceDisplayName)
                     .font(.caption2)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
         }
@@ -321,6 +322,6 @@ struct VersionLink: View {
     private var versionLabel: some View {
         Text(verbatim: versionText)
             .font(font)
-            .foregroundStyle(.tertiary)
+            .foregroundStyle(.secondary)
     }
 }


### PR DESCRIPTION
## Problem

In dark mode the popover rendered its content in **light** appearance — dark text on wallpaper-tinted glass, with the source picker showing up as an opaque white slab.

Confirmed the mechanism rather than guessing at the palette:

```
NSApp.effectiveAppearance: NSAppearanceNameDarkAqua   ← the app knew it was dark
popover default appearance: nil (inherits backdrop)   ← the bug
```

`NSPopover.appearance` defaults to `nil`, so on macOS 26 the glass backdrop resolves the content's appearance from whatever sits behind the popover. Over a light-ish wallpaper it picks light, and every semantic color follows it — resolved via `NSAppearance.performAsCurrentDrawingAppearance`:

| color | Aqua (light) | DarkAqua |
|---|---|---|
| `controlColor` | opaque white | white @ 24.7% alpha |
| `labelColor` | black @ 85% | white @ 85% |

The screenshot showed an opaque-white picker and dark labels: the Aqua values, on a dark-mode system.

## Fix

Assign `NSApp.effectiveAppearance` to the popover, at configure time and again before each show so a theme switch during a running session is picked up. The appearance object is passed through as-is rather than reconstructed from a name via `bestMatch`, so whichever variant the system chooses survives the assignment.

Plus three cleanups the wrong appearance had been masking:

- `.regularMaterial` behind the popover content, so it has its own appearance-correct surface instead of letting wallpaper tint bleed through every label.
- Source picker's hardcoded `Color(nsColor: .controlColor)` → `.fill.quaternary`, so it matches the menu pickers below it.
- Footer source name and version string `.tertiary` → `.secondary` (24.7% → 54.9% white in dark).

## Testing

- `xcodebuild -scheme v2s -configuration Debug` succeeds.
- Appearance resolution verified out-of-process with a small AppKit harness (accessory activation policy, matching `LSUIElement`).

**Not verified:** no visual before/after. Opening the popover needs a synthetic click on the status item, and `osascript` lacks assistive access on this machine — worth an eyeball before merge, particularly whether `.regularMaterial` reads as too opaque against the Tahoe glass (`.ultraThinMaterial` is the easy dial-back).

Also unverified: behaviour under Accessibility → Display → **Increase contrast**. High-contrast appearances resolve dynamically against that setting, so with it off they're indistinguishable from their normal counterparts locally. Direct assignment is the safe form regardless, since it adds no reconstruction step that could drop information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
