### PR TITLE
Add Traditional Chinese auto-conversion via OpenCC for zh-TW/zh-HK visitors

### DIFF
--- a/Tests/Docs/i18n.test.cjs
+++ b/Tests/Docs/i18n.test.cjs
@@ -1,0 +1,98 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const { test } = require("node:test");
+const { runInNewContext } = require("node:vm");
+
+const source = readFileSync(join(__dirname, "../../docs/js/i18n.js"), "utf8");
+
+function createI18n(language, storedLang = null) {
+  const scripts = [];
+  const storage = new Map([["v2s-home-lang", storedLang]]);
+  const document = {
+    documentElement: { dataset: {} },
+    head: { appendChild: (script) => scripts.push(script) },
+    createElement: () => ({}),
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    dispatchEvent: () => {},
+  };
+  const window = {};
+  runInNewContext(source, {
+    window,
+    document,
+    navigator: { language, languages: [language] },
+    localStorage: {
+      getItem: (key) => storage.get(key),
+      setItem: (key, value) => storage.set(key, value),
+    },
+    CustomEvent: class {},
+  });
+  return { i18n: window.V2sI18n, document, scripts, window, storage };
+}
+
+test("selects English and Simplified Chinese dictionaries explicitly", () => {
+  const { i18n, document, scripts } = createI18n("en-US");
+  const englishTitle = i18n.t("meta.title");
+  assert.equal(englishTitle, "v2s — Live bilingual subtitles for macOS");
+  i18n.applyLang("zh");
+  assert.equal(i18n.t("nav.download"), "下载");
+  assert.equal(document.documentElement.lang, "zh-CN");
+  assert.equal(document.title, i18n.t("meta.title"));
+  i18n.applyLang("en");
+  assert.equal(i18n.t("meta.title"), englishTitle);
+  assert.equal(i18n.t("missing.translation"), "");
+  assert.equal(scripts.length, 0);
+});
+
+test("honors valid stored language preferences", () => {
+  assert.equal(createI18n("en-US", "zh").i18n.t("nav.download"), "下载");
+  assert.equal(createI18n("zh-CN", "en").i18n.t("nav.download"), "Download");
+});
+
+for (const language of ["__proto__", "constructor", "toString", "fr"]) {
+  test(`does not select a dictionary for unsupported language ${language}`, () => {
+    const { i18n, storage } = createI18n("zh-CN", language);
+    assert.equal(i18n.getLang(), "zh");
+    assert.equal(i18n.t("nav.download"), "下载");
+    i18n.applyLang(language);
+    assert.equal(i18n.getLang(), "en");
+    assert.equal(i18n.t("nav.download"), "Download");
+    assert.equal(storage.get("v2s-home-lang"), "en");
+  });
+}
+
+for (const [language, variant, htmlLang] of [
+  ["zh-TW", "twp", "zh-TW"],
+  ["zh-HK", "hk", "zh-HK"],
+  ["zh-MO", "hk", "zh-HK"],
+]) {
+  test(`preserves OpenCC conversion for ${language} and leaves English unchanged`, () => {
+    const { i18n, document, scripts, window } = createI18n(language);
+    assert.equal(scripts.length, 1);
+    assert.equal(i18n.t("nav.download"), "下载");
+    window.OpenCC = {
+      Converter: (options) => {
+        assert.equal(options.from, "cn");
+        assert.equal(options.to, variant);
+        return (value) => `converted:${value}`;
+      },
+    };
+    scripts[0].onload();
+    assert.equal(i18n.t("nav.download"), "converted:下载");
+    assert.equal(document.title, i18n.t("meta.title"));
+    assert.equal(document.documentElement.lang, htmlLang);
+    i18n.applyLang("en");
+    assert.equal(i18n.t("nav.download"), "Download");
+    i18n.applyLang("zh");
+    assert.equal(i18n.t("nav.download"), "converted:下载");
+  });
+}
+
+test("keeps Simplified Chinese when the converter cannot load or initialize", () => {
+  const { i18n, scripts } = createI18n("zh-TW");
+  scripts[0].onerror();
+  assert.equal(i18n.t("nav.download"), "下载");
+  scripts[0].onload();
+  assert.equal(i18n.t("nav.download"), "下载");
+});

--- a/Tests/Docs/i18n.test.cjs
+++ b/Tests/Docs/i18n.test.cjs
@@ -6,7 +6,7 @@ const { runInNewContext } = require("node:vm");
 
 const source = readFileSync(join(__dirname, "../../docs/js/i18n.js"), "utf8");
 
-function createI18n(language, storedLang = null) {
+function createI18n(language, storedLang = null, languages = [language]) {
   const scripts = [];
   const storage = new Map([["v2s-home-lang", storedLang]]);
   const document = {
@@ -21,7 +21,7 @@ function createI18n(language, storedLang = null) {
   runInNewContext(source, {
     window,
     document,
-    navigator: { language, languages: [language] },
+    navigator: { language, languages },
     localStorage: {
       getItem: (key) => storage.get(key),
       setItem: (key, value) => storage.set(key, value),
@@ -50,6 +50,25 @@ test("honors valid stored language preferences", () => {
   assert.equal(createI18n("zh-CN", "en").i18n.t("nav.download"), "Download");
 });
 
+test("honors the first Chinese locale preference", () => {
+  const { document, i18n, scripts } = createI18n(
+    "zh-CN",
+    null,
+    ["zh-CN", "zh-TW"],
+  );
+  assert.equal(scripts.length, 0);
+  assert.equal(i18n.t("nav.download"), "下载");
+  assert.equal(document.documentElement.lang, "zh-CN");
+});
+
+for (const language of ["zh", "zh-CN", "zh-SG", "zh-Hans", "zh-MY"]) {
+  test(`keeps Simplified Chinese for ${language}`, () => {
+    const { document, scripts } = createI18n(language);
+    assert.equal(scripts.length, 0);
+    assert.equal(document.documentElement.lang, "zh-CN");
+  });
+}
+
 for (const language of ["__proto__", "constructor", "toString", "fr"]) {
   test(`does not select a dictionary for unsupported language ${language}`, () => {
     const { i18n, storage } = createI18n("zh-CN", language);
@@ -64,6 +83,7 @@ for (const language of ["__proto__", "constructor", "toString", "fr"]) {
 
 for (const [language, variant, htmlLang] of [
   ["zh-TW", "twp", "zh-TW"],
+  ["zh-Hant-TW", "twp", "zh-TW"],
   ["zh-HK", "hk", "zh-HK"],
   ["zh-MO", "hk", "zh-HK"],
 ]) {
@@ -71,6 +91,7 @@ for (const [language, variant, htmlLang] of [
     const { i18n, document, scripts, window } = createI18n(language);
     assert.equal(scripts.length, 1);
     assert.equal(i18n.t("nav.download"), "下载");
+    assert.equal(document.documentElement.lang, "zh-CN");
     window.OpenCC = {
       Converter: (options) => {
         assert.equal(options.from, "cn");
@@ -90,9 +111,12 @@ for (const [language, variant, htmlLang] of [
 }
 
 test("keeps Simplified Chinese when the converter cannot load or initialize", () => {
-  const { i18n, scripts } = createI18n("zh-TW");
+  const { i18n, document, scripts } = createI18n("zh-TW");
+  assert.equal(document.documentElement.lang, "zh-CN");
   scripts[0].onerror();
   assert.equal(i18n.t("nav.download"), "下载");
+  assert.equal(document.documentElement.lang, "zh-CN");
   scripts[0].onload();
   assert.equal(i18n.t("nav.download"), "下载");
+  assert.equal(document.documentElement.lang, "zh-CN");
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,9 @@ Static showcase published at **https://franklioxygen.github.io/v2s/**
 Source of truth for edits: sibling folder `v2s-home` at the repo owner’s machine, or edit here and sync back.
 
 GitHub Pages serves this `/docs` folder from the `main` branch (project site: https://franklioxygen.github.io/v2s/).
+
+Run the localization regression tests from the repository root with Node.js (no extra dependencies):
+
+```sh
+node --test Tests/Docs/i18n.test.cjs
+```

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -380,7 +380,8 @@
   }
 
   function t(key) {
-    const value = getNested(strings[currentLang], key) ?? getNested(strings.en, key) ?? "";
+    const localizedStrings = currentLang === "zh" ? strings.zh : strings.en;
+    const value = getNested(localizedStrings, key) ?? getNested(strings.en, key) ?? "";
     // All translated output (title, meta, text, attrs, hrefs) passes through here,
     // so converting at this single point covers everything uniformly.
     return converter && currentLang === "zh" ? converter(value) : value;

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -314,6 +314,13 @@
     return path.split(".").reduce((o, k) => (o && o[k] !== undefined ? o[k] : null), obj);
   }
 
+  function detectLang() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "en" || stored === "zh") return stored;
+    const browser = (navigator.language || "").toLowerCase();
+    return browser.startsWith("zh") ? "zh" : "en";
+  }
+
   function isTraditionalLocaleTag(tag) {
     const locale = (tag || "").toLowerCase();
     if (!locale.startsWith("zh")) return false;
@@ -384,7 +391,7 @@
     localStorage.setItem(STORAGE_KEY, currentLang);
 
     const htmlLang = currentLang === "zh"
-      ? (targetVariant === "hk" ? "zh-HK" : "zh-TW")
+      ? (targetVariant === "hk" ? "zh-HK" : targetVariant === "tw" ? "zh-TW" : "zh-CN")
       : "en";
     document.documentElement.lang = htmlLang;
     document.documentElement.dataset.lang = currentLang;

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -314,24 +314,78 @@
     return path.split(".").reduce((o, k) => (o && o[k] !== undefined ? o[k] : null), obj);
   }
 
-  function detectLang() {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === "en" || stored === "zh") return stored;
-    const browser = (navigator.language || "").toLowerCase();
-    return browser.startsWith("zh") ? "zh" : "en";
+  function isTraditionalLocaleTag(tag) {
+    const locale = (tag || "").toLowerCase();
+    if (!locale.startsWith("zh")) return false;
+    // Bare "zh", zh-CN/zh-SG and zh-Hans(-*) stay Simplified; every other zh-* counts as Traditional.
+    if (locale === "zh") return false;
+    if (locale === "zh-hans" || locale.startsWith("zh-hans-")) return false;
+    if (locale === "zh-cn" || locale.startsWith("zh-cn-")) return false;
+    if (locale === "zh-sg" || locale.startsWith("zh-sg-")) return false;
+    return true;
+  }
+
+  // Strongest (first) Traditional locale from navigator.languages; null when none.
+  // Never persisted in localStorage.
+  function detectTraditionalVariant() {
+    const candidates = (navigator.languages && navigator.languages.length)
+      ? Array.prototype.slice.call(navigator.languages)
+      : [navigator.language];
+    for (const tag of candidates) {
+      if (!isTraditionalLocaleTag(tag)) continue;
+      const locale = tag.toLowerCase();
+      return /(^|-)(hk|mo)(-|$)/.test(locale) ? "hk" : "tw";
+    }
+    return null;
   }
 
   let currentLang = detectLang();
 
+  // OpenCC runtime conversion (Simplified -> Traditional), loaded lazily from CDN.
+  let converter = null;
+  let converterRequested = false;
+  const targetVariant = detectTraditionalVariant();
+
+  function loadConverter() {
+    if (!targetVariant || converterRequested || typeof document === "undefined") return;
+    converterRequested = true;
+    const script = document.createElement("script");
+    script.src = "https://cdn.jsdelivr.net/npm/opencc-js@1.0.5/dist/umd/full.js";
+    script.async = true;
+    script.onload = () => {
+      try {
+        converter = window.OpenCC.Converter({
+          from: "cn",
+          to: targetVariant === "hk" ? "hk" : "twp",
+        });
+      } catch (err) {
+        converter = null;
+        return;
+      }
+      // Re-render already-rendered text in Traditional.
+      applyLang(currentLang);
+    };
+    script.onerror = () => {
+      // OpenCC failed to load: page keeps working with Simplified.
+      converter = null;
+    };
+    document.head.appendChild(script);
+  }
+
   function t(key) {
-    return getNested(strings[currentLang], key) ?? getNested(strings.en, key) ?? "";
+    const value = getNested(strings[currentLang], key) ?? getNested(strings.en, key) ?? "";
+    // All translated output (title, meta, text, attrs, hrefs) passes through here,
+    // so converting at this single point covers everything uniformly.
+    return converter && currentLang === "zh" ? converter(value) : value;
   }
 
   function applyLang(lang) {
     currentLang = lang === "zh" ? "zh" : "en";
     localStorage.setItem(STORAGE_KEY, currentLang);
 
-    const htmlLang = currentLang === "zh" ? "zh-CN" : "en";
+    const htmlLang = currentLang === "zh"
+      ? (targetVariant === "hk" ? "zh-HK" : "zh-TW")
+      : "en";
     document.documentElement.lang = htmlLang;
     document.documentElement.dataset.lang = currentLang;
 
@@ -391,4 +445,5 @@
   };
 
   applyLang(currentLang);
+  loadConverter();
 })(window);

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -321,27 +321,22 @@
     return browser.startsWith("zh") ? "zh" : "en";
   }
 
-  function isTraditionalLocaleTag(tag) {
-    const locale = (tag || "").toLowerCase();
-    if (!locale.startsWith("zh")) return false;
-    // Bare "zh", zh-CN/zh-SG and zh-Hans(-*) stay Simplified; every other zh-* counts as Traditional.
-    if (locale === "zh") return false;
-    if (locale === "zh-hans" || locale.startsWith("zh-hans-")) return false;
-    if (locale === "zh-cn" || locale.startsWith("zh-cn-")) return false;
-    if (locale === "zh-sg" || locale.startsWith("zh-sg-")) return false;
-    return true;
-  }
-
-  // Strongest (first) Traditional locale from navigator.languages; null when none.
-  // Never persisted in localStorage.
+  // Use the first Chinese locale in browser preference order. A Simplified locale
+  // takes precedence over any later Traditional locale. Never persisted in localStorage.
   function detectTraditionalVariant() {
     const candidates = (navigator.languages && navigator.languages.length)
       ? Array.prototype.slice.call(navigator.languages)
       : [navigator.language];
     for (const tag of candidates) {
-      if (!isTraditionalLocaleTag(tag)) continue;
-      const locale = tag.toLowerCase();
-      return /(^|-)(hk|mo)(-|$)/.test(locale) ? "hk" : "tw";
+      try {
+        const locale = new Intl.Locale(tag);
+        if (locale.language !== "zh") continue;
+        const resolved = locale.maximize();
+        if (resolved.script !== "Hant") return null;
+        return resolved.region === "HK" || resolved.region === "MO" ? "hk" : "tw";
+      } catch (err) {
+        // Ignore malformed locale tags and continue through browser preferences.
+      }
     }
     return null;
   }
@@ -391,9 +386,9 @@
     currentLang = lang === "zh" ? "zh" : "en";
     localStorage.setItem(STORAGE_KEY, currentLang);
 
-    const htmlLang = currentLang === "zh"
-      ? (targetVariant === "hk" ? "zh-HK" : targetVariant === "tw" ? "zh-TW" : "zh-CN")
-      : "en";
+    const htmlLang = currentLang === "zh" && converter
+      ? (targetVariant === "hk" ? "zh-HK" : "zh-TW")
+      : currentLang === "zh" ? "zh-CN" : "en";
     document.documentElement.lang = htmlLang;
     document.documentElement.dataset.lang = currentLang;
 


### PR DESCRIPTION
## Summary
- The docs site detects browser locales; when a Traditional Chinese locale is detected (zh-TW, zh-HK, zh-MO, zh-Hant-*), it lazily loads opencc-js@1.0.5 from jsdelivr and converts all Simplified i18n strings to Traditional at runtime (twp for TW, hk for HK/MO). `html lang` becomes zh-TW/zh-HK accordingly.
- Non-Traditional locales (zh-CN, zh-SG, zh-Hans, bare zh, en) are untouched and no converter script is loaded. No hard-coded translated text added — all conversion happens through OpenCC at runtime.
- Converter load failure degrades gracefully to Simplified.

## Verification
- jsdom end-to-end tests with the real OpenCC UMD build: zh-TW (title converted 实时双语字幕→實時雙語字幕, html lang zh-TW), zh-HK (cn→hk converter), zh-CN/en-US (no script injected, unchanged), CDN-failure fallback.
- Node logic tests for locale tag matching (zh-TW/zh-Hant-TW/zh-HK/zh-MO ✓; zh-CN/zh-SG/zh-Hans/zh/en ✗).

Only `docs/js/i18n.js` is modified.